### PR TITLE
Updated /download/iot page 

### DIFF
--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -8,88 +8,112 @@
 <section class="p-strip is-bordered">
   <div class="row">
     <h1>Get Ubuntu for IoT</h1>
-    <p>Ubuntu Core is a lean, strictly confined and fully transactional operating system. We designed it from the ground up, to focus on security and simplified maintenance, for appliances and large device networks. Ubuntu Core is powered by snaps - the universal Linux packaging format.</p>
-    <p><a href="/core">Learn more about Ubuntu Core ›</p><p> <a href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/" class="p-link--external">Browse all supported images</a></p>
   </div>
-</section>
+  <div class="row p-card u-equal-height">
+    <div class="col-2 u-vertically-center u-align--center">
+      <img src="{{ ASSET_SERVER_URL }}31bd2627-logo-raspberry-pi.svg" width="100" alt="Raspberry Pi">
+    </div>
+    <div class="col-6">
+      <h2>Ubuntu for Raspberry Pi</h2>
+      <p>Get the power, ease and flexibility of Ubuntu for Raspberry Pi 2 or 3.</p>
+      <p>Get started with an Ubuntu Server image for a familiar development environment.</p>
+      <p><a class="p-button--positive" href="/download/iot/raspberry-pi-2-3">Install on Raspberry Pi 2 or 3</a></p>
+    </div>
+    <div class="col-4 u-vertically-center u-align--center">
+      <img src="{{ ASSET_SERVER_URL }}fd0fb85d-1024px-Raspberry_Pi_3_B+__39906369025_-removebg.png?w=200" width="200" alt="">
+    </div>
+  </section>
 
 
-<section class="p-strip--light">
-  <div class="row">
-    <h3>Install Ubuntu Core</h3>
-  </div>
-  <div class="row u-equal-height">
-    <div class="p-card--highlighted col-6">
-      <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}e3a042a7-raspberrypi-card.png?w=115" width="115" alt="Raspberry Pi">
-      <hr class="u-sv1">
-      <p class="p-card__content">Ubuntu Core 18 allows you to install apps on your board in just a few clicks for Raspberry Pi 2 or 3.</p>
-      <p class="u-no-margin--bottom"><a href="/download/iot/raspberry-pi-2-3" class="p-button--neutral is-wide">Install on Raspberry Pi 3 or 2</a></p>
+  <section class="p-strip--light">
+    <div class="row">
+      <div class="col-8">
+        <h2>Supported platforms</h2>
+      </div>
     </div>
-    <div class="p-card--highlighted col-6">
-      <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}d9ccf84b-qualcoom.png?w=132" width="132" alt="Qualcomm Snapdragon">
-      <hr class="u-sv1">
-      <p class="p-card__content">Ubuntu Core 18 helps you harness the power of boards tailored for the IoT ecosystem, like the Dragonboard 410c.</p>
-      <p class="u-no-margin--bottom"><a href="/download/iot/qualcomm-dragonboard-410c" class="p-button--neutral is-wide">Install on Dragonboard 410c</a></p>
+    <div class="row p-divider">
+      <div class="col-4 p-divider__block u-align--center">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}d8d6f38f-RGB_ARTIK-H-cropped.png?h=40"  height="40" alt="Samsung Artik">
+        <p>
+          <img src="{{ ASSET_SERVER_URL }}c2a6714a-ARTIK053_Module-removebg.png?h=84" height="84 alt="">
+        </p>
+        <p>
+          <a href="/download/iot/samsung-artik-5-10-server">Install Ubuntu Server&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+      <div class="col-4 p-divider__block u-align--center">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}1f53b707-JOULE-LOGO.png?h=40" alt="Intel Joule" height="40">
+        <p>
+          <img src="{{ ASSET_SERVER_URL }}6e82053a-intel_joule_module.png?w=150" width="150" alt="">
+        </p>
+        <p>
+          <a href="/download/iot/intel-joule-desktop">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+      <div class="col-4 p-divider__block u-align--center">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}a69b2863-intel+nuc.svg" height="40" alt="Intel NUC">
+        <p>
+          <img src="{{ ASSET_SERVER_URL }}934ef0f7-tall-nuc-frontstraight-rgb-removebg.png?h=84" height="84" alt="">
+        </p>
+        <p>
+          <a href="/download/iot/intel-nuc-desktop">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
+        </p>
+      </div>
     </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="p-card--highlighted col-6">
-      <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}a69b2863-intel+nuc.svg" width="85" alt="Intel NUC">
-      <hr class="u-sv1">
-      <p class="p-card__content">Ubuntu Desktop and Ubuntu Core 18 can be easily installed on other architectures like Intel® 64 bits.</p>
-      <p class="u-no-margin--bottom"><a href="/download/iot/intel-nuc" class="p-button--neutral is-wide">Install on Intel NUC</a></p>
-    </div>
-    <div class="p-card--highlighted col-6">
-      <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}ff8c23f4-logo-pic.png" width="85" alt="Intel IEI TANK 870">
-      <hr class="u-sv1">
-      <p class="p-card__content">Ubuntu Core 18 brings enterprise-grade security to industrial AIoT kits such as the Intel IEI TANK 870.</p>
-      <p class="u-no-margin--bottom"><a href="/download/iot/intel-iei-tank-870" class="p-button--neutral is-wide">Install on Intel IEI TANK 870</a></p>
-    </div>
-  </div>
-  <div class="row">
-    <p>To run Ubuntu Core on your workstation, you can <a href="/download/iot/kvm">install Ubuntu Core in KVM.</a></p>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip">
-  <div class="row">
-    <h3>Other releases</h3>
-  </div>
-  <div class="row">
-    <div class="col-8">
-      <table>
-        <tbody>
-          <tr>
-            <th scope="row"><strong>Raspberry Pi CM3</strong></th>
-            <td><a href="/download/iot/raspberry-pi-compute-module-3">Install Ubuntu Core 16 ›</a></td>
-            <td></td>
-          </tr>
-          <tr>
-            <th scope="row"><strong>UP2</strong></th>
-            <td><a href="/download/iot/up-squared-iot-grove-server">Install Ubuntu Server ›</a></td>
-            <td></td>
-          </tr>
-          <tr>
-            <th scope="row"><strong>Samsung Artik</strong></th>
-            <td><a href="/download/iot/samsung-artik-5-10-server">Install Ubuntu Server ›</a></td>
-            <td class="u-align--right"><a href="/download/iot/samsung-artik-5-10">Install Ubuntu Core 16 ›</a></td>
-          </tr>
-          <tr>
-            <th scope="row"><strong>Intel Joule</strong></th>
-            <td><a href="/download/iot/intel-joule-desktop">Install Ubuntu Desktop ›</a></td>
-            <td class="u-align--right"><a href="/download/iot/intel-joule">Install Ubuntu Core 16 ›</a></td>
-          </tr>
-          <tr>
-            <th scope="row"><strong>Intel NUC</strong></th>
-            <td><a href="/download/iot/intel-nuc-desktop">Install Ubuntu Desktop ›</a></td>
-            <td></td>
-          </tr>
-        </tbody>
-      </table>
+  <section class="p-strip">
+    <div class="row">
+      <h3>Ubuntu Core</h3>
+      <p>Ubuntu Core is a lean, strictly confined and fully transactional operating system. We designed it from the ground up, to focus on security and simplified maintenance, for appliances and large device networks. Ubuntu Core is powered by snaps - the universal Linux packaging format.</p>
+      <p>
+        <a class="p-button--neutral" href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
+      </p>
+
+      <p><a href="/download/iot/kvm">Install Ubuntu Core on your workstation in a KVM&nbsp;&rsaquo;</a></p>
     </div>
-  </div>
-</section>
+    <div class="row">
+      <div class="col-8">
+        <table>
+          <tbody>
+            <tr>
+              <th scope="row"><strong>Raspberry Pi 2 or  3</strong></th>
+              <td class="u-align--right"><a href="/download/iot/raspberry-pi-2-3">Install Ubuntu Core 18&nbsp;&rsaquo;</a></td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Raspberry Pi CM3</strong></th>
+              <td class="u-align--right"><a href="/download/iot/raspberry-pi-compute-module-3">Install Ubuntu Core 18&nbsp;&rsaquo;</a></td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Qualcomm Snapdragon</strong></th>
+              <td class="u-align--right"><a href="/download/iot/qualcomm-dragonboard-410c">Install Ubuntu Core 18&nbsp;&rsaquo;</a></td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Samsung Artik</strong></th>
+              <td class="u-align--right"><a href="/download/iot/samsung-artik-5-10">Install Ubuntu Core 18&nbsp;&rsaquo;</a></td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Intel Joule</strong></th>
+              <td class="u-align--right"><a href="/download/iot/intel-joule">Install Ubuntu Core 18&nbsp;&rsaquo;</a></td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Intel NUC</strong></th>
+              <td class="u-align--right"><a href="/download/iot/intel-nuc">Install Ubuntu Core 18&nbsp;&rsaquo;</a></td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          <a href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/" class="p-link--external">
+            Browse all supported images
+          </a>
+        </p>
+      </div>
+    </div>
+  </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html" with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 
-{% endblock content %}
+
+
+  {% include "shared/contextual_footers/_contextual_footer.html" with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
+
+  {% endblock content %}

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -25,7 +25,7 @@
   </section>
 
 
-  <section class="p-strip--light">
+  <section class="p-strip--light is-bordered">
     <div class="row">
       <div class="col-8">
         <h2>Supported platforms</h2>
@@ -64,7 +64,7 @@
 
   <section class="p-strip">
     <div class="row">
-      <h3>Ubuntu Core</h3>
+      <h2>Ubuntu Core</h2>
       <p>Ubuntu Core is a lean, strictly confined and fully transactional operating system. We designed it from the ground up, to focus on security and simplified maintenance, for appliances and large device networks. Ubuntu Core is powered by snaps - the universal Linux packaging format.</p>
       <p>
         <a class="p-button--neutral" href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
@@ -74,6 +74,7 @@
     </div>
     <div class="row">
       <div class="col-8">
+        <h3>Install Ubuntu Core on</h3>
         <table>
           <tbody>
             <tr>

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -24,7 +24,7 @@
       <p>Get started with an Ubuntu Server image for a familiar development environment.</p>
       <p><a class="p-button--positive" href="/download/iot/raspberry-pi-2-3">Install on Raspberry Pi 2 or 3</a></p>
     </div>
-    <div class="col-4 u-vertically-center u-align--center">
+    <div class="col-4 u-vertically-center u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}fd0fb85d-1024px-Raspberry_Pi_3_B+__39906369025_-removebg.png?w=200" width="200" alt="">
     </div>
   </section>
@@ -38,25 +38,25 @@
     </div>
     <div class="row p-divider">
       <div class="col-3 p-divider__block">
-        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}d8d6f38f-RGB_ARTIK-H-cropped.png?h=40"  height="40" alt="Samsung Artik">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}bb9f2504-2018-logo-artik-01.png"  height="50" alt="Samsung Artik">
         <p>
           <a href="/download/iot/samsung-artik-5-10-server">Install Ubuntu Server&nbsp;&rsaquo;</a>
         </p>
       </div>
       <div class="col-3 p-divider__block">
-        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}1f53b707-JOULE-LOGO.png?h=40" alt="Intel Joule" height="40">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}1f53b707-JOULE-LOGO.png?h=35" alt="Intel Joule" height="35">
         <p>
           <a href="/download/iot/intel-joule-desktop">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
         </p>
       </div>
       <div class="col-3 p-divider__block">
-        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}a69b2863-intel+nuc.svg" height="40" alt="Intel NUC">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}a69b2863-intel+nuc.svg?h=35" height="35" alt="Intel NUC">
         <p>
           <a href="/download/iot/intel-nuc-desktop">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
         </p>
       </div>
       <div class="col-3 p-divider__block">
-        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}8cb47950-g46.png?h=40" height="40" alt="Up2">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}8cb47950-g46.png?h=35" height="35" alt="Up2">
         <p>
           <a href="/download/iot/intel-nuc-desktop">Install Ubuntu Server&nbsp;&rsaquo;</a>
         </p>
@@ -72,11 +72,10 @@
           Ubuntu Core is a lean, strictly confined and fully transactional operating system. We designed it from the ground up, to focus on security and simplified maintenance, for appliances and large device networks. Ubuntu Core is powered by snaps - the universal Linux packaging format.
         </p>
         <p>
-          <a class="p-button--neutral is-inline" href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
-          <a href="/download/iot/kvm">Install on your workstation in a KVM&nbsp;&rsaquo;</a>
+          <a class="p-button--neutral is-inline" style="margin-left: 0;" href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a><br class="u-hide--large u-hide--medium" /><a href="/download/iot/kvm">Install on your workstation in a KVM&nbsp;&rsaquo;</a>
         </p>
       </div>
-      <div class="col-4 u-vertically-center u-align--center">
+      <div class="col-4 u-vertically-center u-align--center u-hide--small">
         <img src="{{ ASSET_SERVER_URL }}805f2b3a-core_black-orange_st_hex.svg" width="125" alt="Ubuntu Core">
       </div>
     </div>
@@ -90,35 +89,33 @@
       <div class="col-4">
         <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/e3a042a7-raspberrypi-card.png?w=115" width="115" alt="Raspberry Pi">
         <p>Install Ubuntu Core 18 on:</p>
-        <ul class="p-list">
-          <li class="p-list--item"><a href="/download/iot/raspberry-pi-2-3-core">Raspberry Pi 2 or  3</a></li>
-          <li class="p-list--item"><a href="/download/iot/raspberry-pi-compute-module-3">Raspberry Pi CM3</a></li>
-        </ul>
+        <p><a href="/download/iot/raspberry-pi-2-3-core">Raspberry Pi 2 or  3&nbsp;&rsaquo;</a><br />
+          <a href="/download/iot/raspberry-pi-compute-module-3">Raspberry Pi CM3&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4">
-        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/a69b2863-intel+nuc.svg" width="85" alt="Intel NUC">
+        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/a69b2863-intel+nuc.svg?h=35" height="35" alt="Intel NUC">
         <p><a href="/download/iot/intel-nuc">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4">
-        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/ff8c23f4-logo-pic.png?w=85" width="85" alt="Intel IEI TANK 870">
+        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/ff8c23f4-logo-pic.png?h=35" height="35" alt="Intel IEI TANK 870">
         <p><a href="/download/iot/intel-iei-tank-870">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
       </div>
     </div>
-    <div class="row u-equal-height">
+    <div class="row u-equal-height" style="margin-top: 2rem;">
       <div class="col-4">
-        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/d9ccf84b-qualcoom.png?w=132" width="132" alt="Qualcomm Snapdragon">
+        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/d9ccf84b-qualcoom.png?h=35" height="35" alt="Qualcomm Snapdragon">
         <p><a href="/download/iot/qualcomm-dragonboard-410c">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4">
-        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}d8d6f38f-RGB_ARTIK-H-cropped.png?h=40"  height="40" alt="Samsung Artik">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}bb9f2504-2018-logo-artik-01.png?h=40"  height="40" alt="Samsung Artik">
         <p><a href="/download/iot/samsung-artik-5-10">Install Ubuntu Core 16&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4">
-        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}1f53b707-JOULE-LOGO.png?h=40" alt="Intel Joule">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}1f53b707-JOULE-LOGO.png?h=35" height="35" alt="Intel Joule">
         <p><a href="/download/iot/intel-joule">Install Ubuntu Core 16&nbsp;&rsaquo;</a></p>
       </div>
     </div>
-    <div class="row">
+    <div class="row" style="margin-top: 2rem;">
       <p>
         <a class="p-button--neutral" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/">
           <span class="p-link--external">Browse all supported images</span>

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -5,16 +5,21 @@
 
 {% block content %}
 
-<section class="p-strip is-bordered">
+<section class="p-strip">
   <div class="row">
     <h1>Get Ubuntu for IoT</h1>
   </div>
-  <div class="row p-card u-equal-height">
-    <div class="col-2 u-vertically-center u-align--center">
-      <img src="{{ ASSET_SERVER_URL }}31bd2627-logo-raspberry-pi.svg" width="100" alt="Raspberry Pi">
-    </div>
-    <div class="col-6">
-      <h2>Ubuntu for Raspberry Pi</h2>
+</section>
+<section class="p-strip--light">
+
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}31bd2627-logo-raspberry-pi.svg"  alt="Raspberry Pi">
+          <h2 class="p-heading-icon__title">Ubuntu for Raspberry Pi</h2>
+        </div>
+      </div>
       <p>Get the power, ease and flexibility of Ubuntu for Raspberry Pi 2 or 3.</p>
       <p>Get started with an Ubuntu Server image for a familiar development environment.</p>
       <p><a class="p-button--positive" href="/download/iot/raspberry-pi-2-3">Install on Raspberry Pi 2 or 3</a></p>
@@ -25,95 +30,102 @@
   </section>
 
 
-  <section class="p-strip--light is-bordered">
+  <section class="p-strip">
     <div class="row">
       <div class="col-8">
-        <h2>Supported platforms</h2>
+        <h3>Supported platforms</h3>
       </div>
     </div>
     <div class="row p-divider">
-      <div class="col-4 p-divider__block u-align--center">
+      <div class="col-3 p-divider__block">
         <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}d8d6f38f-RGB_ARTIK-H-cropped.png?h=40"  height="40" alt="Samsung Artik">
-        <p>
-          <img src="{{ ASSET_SERVER_URL }}c2a6714a-ARTIK053_Module-removebg.png?h=84" height="84 alt="">
-        </p>
         <p>
           <a href="/download/iot/samsung-artik-5-10-server">Install Ubuntu Server&nbsp;&rsaquo;</a>
         </p>
       </div>
-      <div class="col-4 p-divider__block u-align--center">
+      <div class="col-3 p-divider__block">
         <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}1f53b707-JOULE-LOGO.png?h=40" alt="Intel Joule" height="40">
-        <p>
-          <img src="{{ ASSET_SERVER_URL }}6e82053a-intel_joule_module.png?w=150" width="150" alt="">
-        </p>
         <p>
           <a href="/download/iot/intel-joule-desktop">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
         </p>
       </div>
-      <div class="col-4 p-divider__block u-align--center">
+      <div class="col-3 p-divider__block">
         <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}a69b2863-intel+nuc.svg" height="40" alt="Intel NUC">
-        <p>
-          <img src="{{ ASSET_SERVER_URL }}934ef0f7-tall-nuc-frontstraight-rgb-removebg.png?h=84" height="84" alt="">
-        </p>
         <p>
           <a href="/download/iot/intel-nuc-desktop">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
         </p>
+      </div>
+      <div class="col-3 p-divider__block">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}8cb47950-g46.png?h=40" height="40" alt="Up2">
+        <p>
+          <a href="/download/iot/intel-nuc-desktop">Install Ubuntu Server&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip--light">
+    <div class="row u-equal-height">
+      <div class="col-8">
+        <h2>Ubuntu Core</h2>
+        <p>
+          Ubuntu Core is a lean, strictly confined and fully transactional operating system. We designed it from the ground up, to focus on security and simplified maintenance, for appliances and large device networks. Ubuntu Core is powered by snaps - the universal Linux packaging format.
+        </p>
+        <p>
+          <a class="p-button--neutral is-inline" href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
+          <a href="/download/iot/kvm">Install on your workstation in a KVM&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+      <div class="col-4 u-vertically-center u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}805f2b3a-core_black-orange_st_hex.svg" width="125" alt="Ubuntu Core">
       </div>
     </div>
   </section>
 
   <section class="p-strip">
     <div class="row">
-      <h2>Ubuntu Core</h2>
-      <p>Ubuntu Core is a lean, strictly confined and fully transactional operating system. We designed it from the ground up, to focus on security and simplified maintenance, for appliances and large device networks. Ubuntu Core is powered by snaps - the universal Linux packaging format.</p>
-      <p>
-        <a class="p-button--neutral" href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
-      </p>
-
-      <p><a href="/download/iot/kvm">Install Ubuntu Core on your workstation in a KVM&nbsp;&rsaquo;</a></p>
+      <h3>Supported platforms</h3>
     </div>
-    <div class="row">
-      <div class="col-8">
-        <h3>Install Ubuntu Core on</h3>
-        <table>
-          <tbody>
-            <tr>
-              <th scope="row"><strong>Raspberry Pi 2 or  3</strong></th>
-              <td class="u-align--right"><a href="/download/iot/raspberry-pi-2-3">Install Ubuntu Core 18&nbsp;&rsaquo;</a></td>
-            </tr>
-            <tr>
-              <th scope="row"><strong>Raspberry Pi CM3</strong></th>
-              <td class="u-align--right"><a href="/download/iot/raspberry-pi-compute-module-3">Install Ubuntu Core 18&nbsp;&rsaquo;</a></td>
-            </tr>
-            <tr>
-              <th scope="row"><strong>Qualcomm Snapdragon</strong></th>
-              <td class="u-align--right"><a href="/download/iot/qualcomm-dragonboard-410c">Install Ubuntu Core 18&nbsp;&rsaquo;</a></td>
-            </tr>
-            <tr>
-              <th scope="row"><strong>Samsung Artik</strong></th>
-              <td class="u-align--right"><a href="/download/iot/samsung-artik-5-10">Install Ubuntu Core 18&nbsp;&rsaquo;</a></td>
-            </tr>
-            <tr>
-              <th scope="row"><strong>Intel Joule</strong></th>
-              <td class="u-align--right"><a href="/download/iot/intel-joule">Install Ubuntu Core 18&nbsp;&rsaquo;</a></td>
-            </tr>
-            <tr>
-              <th scope="row"><strong>Intel NUC</strong></th>
-              <td class="u-align--right"><a href="/download/iot/intel-nuc">Install Ubuntu Core 18&nbsp;&rsaquo;</a></td>
-            </tr>
-          </tbody>
-        </table>
-        <p>
-          <a href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/" class="p-link--external">
-            Browse all supported images
-          </a>
-        </p>
+    <div class="row u-equal-height">
+      <div class="col-4">
+        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/e3a042a7-raspberrypi-card.png?w=115" width="115" alt="Raspberry Pi">
+        <p>Install Ubuntu Core 18 on:</p>
+        <ul class="p-list">
+          <li class="p-list--item"><a href="/download/iot/raspberry-pi-2-3-core">Raspberry Pi 2 or  3</a></li>
+          <li class="p-list--item"><a href="/download/iot/raspberry-pi-compute-module-3">Raspberry Pi CM3</a></li>
+        </ul>
+      </div>
+      <div class="col-4">
+        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/a69b2863-intel+nuc.svg" width="85" alt="Intel NUC">
+        <p><a href="/download/iot/intel-nuc">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-4">
+        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/ff8c23f4-logo-pic.png?w=85" width="85" alt="Intel IEI TANK 870">
+        <p><a href="/download/iot/intel-iei-tank-870">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
       </div>
     </div>
+    <div class="row u-equal-height">
+      <div class="col-4">
+        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/d9ccf84b-qualcoom.png?w=132" width="132" alt="Qualcomm Snapdragon">
+        <p><a href="/download/iot/qualcomm-dragonboard-410c">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-4">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}d8d6f38f-RGB_ARTIK-H-cropped.png?h=40"  height="40" alt="Samsung Artik">
+        <p><a href="/download/iot/samsung-artik-5-10">Install Ubuntu Core 16&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-4">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}1f53b707-JOULE-LOGO.png?h=40" alt="Intel Joule">
+        <p><a href="/download/iot/intel-joule">Install Ubuntu Core 16&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+    <div class="row">
+      <p>
+        <a class="p-button--neutral" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/">
+          <span class="p-link--external">Browse all supported images</span>
+        </a>
+      </p>
+    </div>
   </section>
-
-
-
 
   {% include "shared/contextual_footers/_contextual_footer.html" with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 


### PR DESCRIPTION
## Done

- Updated /download/iot page to focus on non-Core downloads to get people started

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/iot/](http://0.0.0.0:8001/download/iot)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1Sxdl5cGGe1wbHmKB2eL2zQLfVW3KBea02a2FIGx3VdQ/edit#)

## Issue / Card

Fixes #4954

