### PR TITLE
New /download/iot/raspberry-pi-2-3 page with ubuntu server

### DIFF
--- a/templates/download/iot/_boot-tips-strip.html
+++ b/templates/download/iot/_boot-tips-strip.html
@@ -7,8 +7,5 @@
         <li>There is no default <code>ubuntu</code> user on these images, but you can run <code>sudo passwd &lt;account name&gt;</code> to set a password if you need a local console login.</li>
       </ul>
     </div>
-    <div class="col-4 u-hide--small u-align--center u-vertically-center">
-      <img src="{{ ASSET_SERVER_URL }}e2047558-pictogram-knowledge-orange-white-background.svg" alt="" width="180">
-    </div>
   </div>
 </section>

--- a/templates/download/iot/_flash-image.html
+++ b/templates/download/iot/_flash-image.html
@@ -4,6 +4,6 @@
     Flash the {{ card|default:"card" }}
   </h3>
   <div class="p-list-step__content">
-    <p>Copy the Ubuntu Core image on the {{ card|default:"card" }} by following the <a class="p-link" href="/download/iot/installation-media">installation media instructions</a>.</p>
+    <p>Copy the Ubuntu image on the {{ card|default:"card" }} by following the <a class="p-link" href="/download/iot/installation-media">installation media instructions</a>.</p>
   </div>
 </li>

--- a/templates/download/iot/installation-media.html
+++ b/templates/download/iot/installation-media.html
@@ -1,6 +1,6 @@
 {% extends "download/_base_download.html" %}
 
-{% block title %}Create installation media for Ubuntu Core{% endblock %}}
+{% block title %}Create installation media for Ubuntu{% endblock %}}
 {% block meta_copydoc %}{% endblock meta_copydoc %}
 
 {% block content %}
@@ -8,8 +8,8 @@
   <div class="row">
     <div class="col-8">
       <div>
-         <h1>Create installation media for Ubuntu Core</h1>
-        <p>These steps will walk you through creating a bootable Ubuntu Core SD Card or USB flash drive.</p>
+         <h1>Create installation media for Ubuntu</h1>
+        <p>These steps will walk you through creating a bootable Ubuntu image SD Card or USB flash drive.</p>
         <div class="p-notification--caution">
           <p class="p-notification__response">
             <span class="p-notification__status">WARNING:</span>This will erase any existing content on the removable drive!
@@ -30,7 +30,7 @@
           <li class="p-list-step__item col-8">
               <p class="p-list-step__title">
                 <span class="p-list-step__bullet">1</span>
-                Download the Ubuntu Core image for your device in your <strong>`Downloads`</strong> folder
+                Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
               </p>
             </li>
             <li class="p-list-step__item col-8">
@@ -60,7 +60,7 @@
           <li class="p-list-step__item col-8">
               <p class="p-list-step__title">
                 <span class="p-list-step__bullet">*</span>
-                If the Ubuntu Core image file you have downloaded ends with an `.xz` file extension, run:
+                If the Ubuntu image file you have downloaded ends with an `.xz` file extension, run:
               </p>
               <pre><code>xzcat ~/Downloads/ &lt; image file .xz &gt; | sudo dd of=&lt; drive address &gt; bs=32M</code></pre>
           </li>
@@ -80,7 +80,7 @@
           <li class="p-list-step__item col-8">
               <p class="p-list-step__title">
                 <span class="p-list-step__bullet">*</span>
-                You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu Core on your device ›</a>
+                You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
               </p>
           </li>
       </ol>
@@ -96,13 +96,13 @@
           <li class="p-list-step__item col-8">
             <p class="p-list-step__title">
               <span class="p-list-step__bullet">1</span>
-              Download the Ubuntu Core image for your device in your <strong>`Downloads`</strong> folder
+              Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
             </p>
           </li>
           <li class="p-list-step__item col-8">
             <p class="p-list-step__title">
               <span class="p-list-step__bullet">*</span>
-              If the Ubuntu Core image file you have downloaded ends with an .xz file extension, you will need to extract it first. To do so, you might have to install an archive extractor software, like <a class="p-link--external" href="http://www.7-zip.org/">7-zip</a>
+              If the Ubuntu image file you have downloaded ends with an .xz file extension, you will need to extract it first. To do so, you might have to install an archive extractor software, like <a class="p-link--external" href="http://www.7-zip.org/">7-zip</a>
             </p>
           </li>
           <li class="p-list-step__item col-8">
@@ -146,7 +146,7 @@
             <li class="p-list-step__item col-8">
                 <p class="p-list-step__title">
                   <span class="p-list-step__bullet">*</span>
-                  You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu Core on your device ›</a>
+                  You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
                 </p>
               </li>
           </ol>
@@ -160,7 +160,7 @@
               <li class="p-list-step__item col-8">
                 <p class="p-list-step__title">
                   <span class="p-list-step__bullet">1</span>
-                  Download the Ubuntu Core image for your device in your <strong>`Downloads`</strong> folder
+                  Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
                 </p>
               </li>
               <li class="p-list-step__item col-8">
@@ -228,7 +228,7 @@
                   <li class="p-list-step__item col-8">
                       <p class="p-list-step__title">
                         <span class="p-list-step__bullet">*</span>
-                        You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu Core on your device ›</a>
+                        You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
                       </p>
                     </li>
 </section>

--- a/templates/download/iot/installation-media.html
+++ b/templates/download/iot/installation-media.html
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="col-8">
       <div>
-         <h1>Create installation media for Ubuntu</h1>
+        <h1>Create installation media for Ubuntu</h1>
         <p>These steps will walk you through creating a bootable Ubuntu image SD Card or USB flash drive.</p>
         <div class="p-notification--caution">
           <p class="p-notification__response">
@@ -21,68 +21,67 @@
   </div>
 </section>
 
-
 <section class="p-strip--light is-bordered">
   <div class="row" id="ubuntu">
     <div class="col-12">
       <h2>On Ubuntu</h2>
       <ol class="p-list-step">
-          <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
-                <span class="p-list-step__bullet">1</span>
-                Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
-              </p>
-            </li>
-            <li class="p-list-step__item col-8">
-                <p class="p-list-step__title">
-                  <span class="p-list-step__bullet">*</span>
-                  Insert your SD card or USB flash drive
-                </p>
-              </li>
-          <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
-                <span class="p-list-step__bullet">*</span>
-                Identify its address by opening the "Disks" application and look for the "Device" line. If the line is in the <code>/dev/mmcblk0p1</code> format, then your drive address is: <code>/dev/mmcblk0</code>. If it is in the <code>/dev/sdb1</code> format, then the address is <code>/dev/sdb</code>
-              </p>
-          </li>
-          <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
-                <span class="p-list-step__bullet">*</span>
-                Unmount it by right-clicking its icon in the launcher bar, the eject icon in a file manager or the square icon in the "Disks" application
-              </p>
-          </li>
-          <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
-                <span class="p-list-step__bullet">*</span>
-                Open a terminal (<code>Ctrl+Alt+T</code>) to copy the image to your removable drive
-              </p>
-          </li>
-          <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
-                <span class="p-list-step__bullet">*</span>
-                If the Ubuntu image file you have downloaded ends with an `.xz` file extension, run:
-              </p>
-              <pre><code>xzcat ~/Downloads/ &lt; image file .xz &gt; | sudo dd of=&lt; drive address &gt; bs=32M</code></pre>
-          </li>
-          <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
-                <span class="p-list-step__bullet">*</span>
-                Else, run:
-              </p>
-              <pre><code>sudo dd if=~/Downloads/&lt; image file &gt; of=&lt; drive address &gt; bs=32M</code></pre>
-          </li>
-          <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
-                <span class="p-list-step__bullet">*</span>
-                Then, run the <code>sync</code> command to finalize the process
-              </p>
-          </li>
-          <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
-                <span class="p-list-step__bullet">*</span>
-                You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
-              </p>
-          </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">1</span>
+            Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
+          </p>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            Insert your SD card or USB flash drive
+          </p>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            Identify its address by opening the "Disks" application and look for the "Device" line. If the line is in the <code>/dev/mmcblk0p1</code> format, then your drive address is: <code>/dev/mmcblk0</code>. If it is in the <code>/dev/sdb1</code> format, then the address is <code>/dev/sdb</code>
+          </p>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            Unmount it by right-clicking its icon in the launcher bar, the eject icon in a file manager or the square icon in the "Disks" application
+          </p>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            Open a terminal (<code>Ctrl+Alt+T</code>) to copy the image to your removable drive
+          </p>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            If the Ubuntu image file you have downloaded ends with an `.xz` file extension, run:
+          </p>
+          <pre><code>xzcat ~/Downloads/ &lt; image file .xz &gt; | sudo dd of=&lt; drive address &gt; bs=32M</code></pre>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            Else, run:
+          </p>
+          <pre><code>sudo dd if=~/Downloads/&lt; image file &gt; of=&lt; drive address &gt; bs=32M</code></pre>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            Then, run the <code>sync</code> command to finalize the process
+          </p>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
+          </p>
+        </li>
       </ol>
     </div>
   </div>
@@ -92,148 +91,147 @@
   <div class="row" id="windows">
     <div class="col-12">
       <h2>On Windows</h2>
-        <ol class="p-list-step">
-          <li class="p-list-step__item col-8">
-            <p class="p-list-step__title">
-              <span class="p-list-step__bullet">1</span>
-              Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
-            </p>
-          </li>
-          <li class="p-list-step__item col-8">
-            <p class="p-list-step__title">
-              <span class="p-list-step__bullet">*</span>
-              If the Ubuntu image file you have downloaded ends with an .xz file extension, you will need to extract it first. To do so, you might have to install an archive extractor software, like <a class="p-link--external" href="http://www.7-zip.org/">7-zip</a>
-            </p>
-          </li>
-          <li class="p-list-step__item col-8">
-            <p class="p-list-step__title">
-              <span class="p-list-step__bullet">*</span>
-              Insert your SD card or USB flash drive
-            </p>
-          </li>
-          <li class="p-list-step__item col-8">
-            <p class="p-list-step__title">
-              <span class="p-list-step__bullet">*</span>
-              Download and install <a class="p-link--external" href="http://sourceforge.net/projects/win32diskimager/files/latest/download">Win32DiskImager</a>, then launch it
-            </p>
-          </li>
-          <li class="p-list-step__item col-8">
-            <p class="p-list-step__title">
-              <span class="p-list-step__bullet">*</span>
-              Find out where your removable drive is mounted by opening a File Explorer window to check which mount point the drive is listed under. Here is an example of an SD card listed under <strong>E:</strong>
-            </p>
-            <p>
-              <img alt="" src="http://i.imgur.com/QXLkLsa.png?w=138" width="138" />
-            </p>
-          </li>
-          <li class="p-list-step__item col-8">
+      <ol class="p-list-step">
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">1</span>
+            Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
+          </p>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            If the Ubuntu image file you have downloaded ends with an .xz file extension, you will need to extract it first. To do so, you might have to install an archive extractor software, like <a class="p-link--external" href="http://www.7-zip.org/">7-zip</a>
+          </p>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            Insert your SD card or USB flash drive
+          </p>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            Download and install <a class="p-link--external" href="http://sourceforge.net/projects/win32diskimager/files/latest/download">Win32DiskImager</a>, then launch it
+          </p>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            Find out where your removable drive is mounted by opening a File Explorer window to check which mount point the drive is listed under. Here is an example of an SD card listed under <strong>E:</strong>
+          </p>
+          <p>
+            <img alt="" src="http://i.imgur.com/QXLkLsa.png?w=138" width="138" />
+          </p>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            In order to flash your card with the Ubuntu image, Win32DiskImager will need 2 elements:
+          </p>
+          <ol>
+            <li>an <strong>Image File</strong>: navigate to your <code>Downloads</code> folder and select the image you have just extracted</li>
+            <li>a <strong>Device</strong>: the location of your SD card. Select the drive on which your SD card is mounted</li>
+            <p><img alt="" src="http://i.imgur.com/ebeQHKT.png?w=421" width="421" /></p>
+          </ol>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            When ready click on <strong>Write</strong> and wait for the process to complete.
+          </p>
+        </li>
+        <li class="p-list-step__item col-8">
+          <p class="p-list-step__title">
+            <span class="p-list-step__bullet">*</span>
+            You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
+          </p>
+        </li>
+      </ol>
+    </section>
+
+    <section class="p-strip--light is-bordered">
+      <div class="row" id="macos">
+        <div class="col-12">
+          <h2>On MacOS</h2>
+          <ol class="p-list-step">
+            <li class="p-list-step__item col-8">
               <p class="p-list-step__title">
-                <span class="p-list-step__bullet">*</span>
-                In order to flash your card with the Ubuntu image, Win32DiskImager will need 2 elements:
-              </p>
-              <ol>
-                <li>an <strong>Image File</strong>: navigate to your <code>Downloads</code> folder and select the image you have just extracted</li>
-                <li>a <strong>Device</strong>: the location of your SD card. Select the drive on which your SD card is mounted</li>
-                <p><img alt="" src="http://i.imgur.com/ebeQHKT.png?w=421" width="421" /></p>
-              </ol>
-          </li>
-          <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
-                <span class="p-list-step__bullet">*</span>
-                When ready click on <strong>Write</strong> and wait for the process to complete.
+                <span class="p-list-step__bullet">1</span>
+                Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
               </p>
             </li>
             <li class="p-list-step__item col-8">
+              <p class="p-list-step__title">
+                <span class="p-list-step__bullet">*</span>
+                Insert your SD card or USB flash drive
+              </p>
+            </li>
+            <li class="p-list-step__item col-8">
+              <p class="p-list-step__title">
+                <span class="p-list-step__bullet">*</span>
+                Open a terminal window (Go to <strong>Application</strong> » <strong>Utilities</strong>, you will find the Terminal app there), then run the following command:
+              </p>
+              <p><pre><code>diskutil list</code></pre></p>
+            </li>
+            <li class="p-list-step__item col-8">
+              <p class="p-list-step__title">
+                <span class="p-list-step__bullet">*</span>
+                In the results, identify your removable drive device address, it will probably look like an entry like the ones below:
+              </p>
+              <pre>
+                <code>/dev/disk0
+                  #:                       TYPE NAME                    SIZE       IDENTIFIER
+                  0:      GUID_partition_scheme                        *500.3 GB   disk0
+                  /dev/disk2
+                  #:                       TYPE NAME                    SIZE       IDENTIFIER
+                  0:                  Apple_HFS Macintosh HD           *428.8 GB   disk1
+                  Logical Volume on disk0s2
+                  E2E7C215-99E4-486D-B3CC-DAB8DF9E9C67
+                  Unlocked Encrypted
+                  /dev/disk3
+                  #:                       TYPE NAME                    SIZE       IDENTIFIER
+                  0:     FDisk_partition_scheme                        *7.9 GB     disk3
+                  1:                 DOS_FAT_32 NO NAME                 7.9 GB     disk3s1
+                </code></pre>
+                <p><strong>Note</strong> that your removable drive must be <code>DOS_FAT_32</code> formatted. In this example, <code>/dev/disk3</code> is the drive address of an 8GB SD card.</p>
+              </li>
+              <li class="p-list-step__item col-8">
                 <p class="p-list-step__title">
                   <span class="p-list-step__bullet">*</span>
-                  You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
+                  Unmount your SD card with the following command
                 </p>
+                <pre><code>diskutil unmountDisk &lt; drive address &gt;</code></pre>
               </li>
-          </ol>
-        </section>
-
-<section class="p-strip--light is-bordered">
-    <div class="row" id="macos">
-        <div class="col-12">
-          <h2>On MacOS</h2>
-            <ol class="p-list-step">
               <li class="p-list-step__item col-8">
                 <p class="p-list-step__title">
-                  <span class="p-list-step__bullet">1</span>
-                  Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
+                  <span class="p-list-step__bullet">*</span>
+                  When successful, you should see a message similar to this one:
                 </p>
+                <pre><code>Unmount of all volumes on &lt; drive address &gt; was successful</code></pre>
               </li>
               <li class="p-list-step__item col-8">
-                  <p class="p-list-step__title">
-                    <span class="p-list-step__bullet">*</span>
-                    Insert your SD card or USB flash drive
-                  </p>
+                <p class="p-list-step__title">
+                  <span class="p-list-step__bullet">*</span>
+                  You can now copy the image to the SD card, using the following command:
+                </p>
+                <pre><code>sudo sh -c 'xzcat ~/Downloads/&lt; image file &gt; | sudo dd of=&lt; drive address &gt; bs=32m'</code></pre>
+                <p>When finalised you will see the following message:</p>
+                <pre>
+                  <code>3719+1 records in
+                    3719+1 records out
+                    3899999744 bytes transferred in 642.512167 secs (6069924 bytes/sec)
+                  </code></pre>
                 </li>
                 <li class="p-list-step__item col-8">
-                    <p class="p-list-step__title">
-                      <span class="p-list-step__bullet">*</span>
-                      Open a terminal window (Go to <strong>Application</strong> » <strong>Utilities</strong>, you will find the Terminal app there), then run the following command:
-                    </p>
-                    <p><pre><code>diskutil list</code></pre></p>
-                  </li>
-                <li class="p-list-step__item col-8">
                   <p class="p-list-step__title">
                     <span class="p-list-step__bullet">*</span>
-                    In the results, identify your removable drive device address, it will probably look like an entry like the ones below:
+                    You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
                   </p>
-                  <pre>
-<code>/dev/disk0
-#:                       TYPE NAME                    SIZE       IDENTIFIER
-0:      GUID_partition_scheme                        *500.3 GB   disk0
-/dev/disk2
-#:                       TYPE NAME                    SIZE       IDENTIFIER
-0:                  Apple_HFS Macintosh HD           *428.8 GB   disk1
-                              Logical Volume on disk0s2
-                              E2E7C215-99E4-486D-B3CC-DAB8DF9E9C67
-                              Unlocked Encrypted
-/dev/disk3
-#:                       TYPE NAME                    SIZE       IDENTIFIER
-0:     FDisk_partition_scheme                        *7.9 GB     disk3
-1:                 DOS_FAT_32 NO NAME                 7.9 GB     disk3s1
-</code></pre>
-                  <p><strong>Note</strong> that your removable drive must be <code>DOS_FAT_32</code> formatted. In this example, <code>/dev/disk3</code> is the drive address of an 8GB SD card.</p>
                 </li>
-                <li class="p-list-step__item col-8">
-                    <p class="p-list-step__title">
-                      <span class="p-list-step__bullet">*</span>
-                      Unmount your SD card with the following command
-                    </p>
-                    <pre><code>diskutil unmountDisk &lt; drive address &gt;</code></pre>
-                  </li>
-                <li class="p-list-step__item col-8">
-                    <p class="p-list-step__title">
-                      <span class="p-list-step__bullet">*</span>
-                      When successful, you should see a message similar to this one:
-                    </p>
-                    <pre><code>Unmount of all volumes on &lt; drive address &gt; was successful</code></pre>
-                  </li>
-                  <li class="p-list-step__item col-8">
-                    <p class="p-list-step__title">
-                      <span class="p-list-step__bullet">*</span>
-                      You can now copy the image to the SD card, using the following command:
-                    </p>
-                    <pre><code>sudo sh -c 'xzcat ~/Downloads/&lt; image file &gt; | sudo dd of=&lt; drive address &gt; bs=32m'</code></pre>
-                    <p>When finalised you will see the following message:</p>
-                    <pre>
-<code>3719+1 records in
-3719+1 records out
-3899999744 bytes transferred in 642.512167 secs (6069924 bytes/sec)
-</code></pre>
-                  </li>
-                  <li class="p-list-step__item col-8">
-                      <p class="p-list-step__title">
-                        <span class="p-list-step__bullet">*</span>
-                        You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
-                      </p>
-                    </li>
-</section>
+              </section>
 
+              {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
-
-{% endblock content %}
+              {% endblock content %}

--- a/templates/download/iot/raspberry-pi-2-3-core.html
+++ b/templates/download/iot/raspberry-pi-2-3-core.html
@@ -1,0 +1,88 @@
+{% extends "download/_base_download.html" %}
+
+{% block title %}Install Ubuntu Core on a Raspberry Pi 2 or 3{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Ig906jbgB39QHw61uHMvIsRbSBUjchJBDkMZl0WzlWM/edit{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <div>
+        <h1>Install Ubuntu Core on a Raspberry Pi 2 or 3</h1>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 p-card">
+      <div class="u-equal-height p-divider">
+        <div class="col-6 p-divider__block">
+          <h2>Install Ubuntu Core</h2>
+          <p>We will walk you through the steps of flashing Ubuntu Core on a Raspberry Pi 2 or 3. At the end of this process, you will have a board ready for production or testing snaps.</p>
+        </div>
+        <div class="col-6 p-divider__block">
+          <h3>Minimum requirements</h3>
+          <ul class="p-list">
+            <li class="p-list__item is-ticked">A Raspberry Pi 2 or 3</li>
+            <li class="p-list__item is-ticked">A microSD card</li>
+            <li class="p-list__item is-ticked">An Ubuntu Core image</li>
+            <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
+            <li class="p-list__item is-ticked">An HDMI cable</li>
+            <li class="p-list__item is-ticked">A USB keyboard</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Installation instructions</h2>
+      <ol class="p-stepped-list--detailed">
+        {% include "./_setup-ubuntu-sso.html" with number=1 %}
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">2</span>
+            Download Ubuntu Core
+          </h3>
+          <div class="p-list-step__content">
+            <p>Get the correct Ubuntu Core image for your board:</p>
+            <ul class="u-no-margin--left">
+              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Ubuntu Core 18 image for Raspberry Pi 2.</a>
+              </li>
+              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz">Ubuntu Core 18 image for Raspberry Pi 3.</a></li>
+              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
+              </li>
+            </ul>
+          </div>
+        </li>
+        {% include "./_flash-image.html" with card="microSD card" number=3 %}
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">4</span>
+            Install Ubuntu Core
+          </h3>
+          <div class="p-list-step__content">
+            <ol class="u-no-margin--left">
+              <li>Attach the monitor and keyboard to the board. You can alternatively use a serial cable.</li>
+              <li>Insert the microSD card and plug the power adaptor into the board.</li>
+            </ol>
+          </div>
+        </li>
+        {% include "./_first-boot-setup.html" with number=5 %}
+        {% include "./_login.html" with number=6 %}
+      </ol>
+    </div>
+  </div>
+</section>
+
+{% include "./_boot-tips-strip.html" with strip="p-strip--light" %}
+
+{% include "./_install-snaps-strip.html" %}
+
+{% include "download/shared/_get-ebook-security.html"%}
+
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
+
+{% endblock content %}

--- a/templates/download/iot/raspberry-pi-2-3.html
+++ b/templates/download/iot/raspberry-pi-2-3.html
@@ -1,30 +1,33 @@
 {% extends "download/_base_download.html" %}
 
-{% block title %}Install Ubuntu Core on a Raspberry Pi 2 or 3{% endblock %}}
-{% block meta_copydoc %}https://docs.google.com/document/d/1Ig906jbgB39QHw61uHMvIsRbSBUjchJBDkMZl0WzlWM/edit{% endblock meta_copydoc %}
+{% block title %}Install Ubuntu Server on a Raspberry Pi 2 or 3{% endblock %}}
+{% block meta_copydoc %}https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit#{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
       <div>
-        <h1>Install Ubuntu Core on a Raspberry Pi 2 or 3</h1>
+        <h1>Install Ubuntu Server on a Raspberry Pi 2 or 3</h1>
       </div>
+    </div>
+    <div class="col-4 u-vertically-center u-align--center">
+      <img src="{{ ASSET_SERVER_URL }}31bd2627-logo-raspberry-pi.svg" width="100" alt="Raspberry Pi">
     </div>
   </div>
   <div class="row">
     <div class="col-12 p-card">
       <div class="u-equal-height p-divider">
         <div class="col-6 p-divider__block">
-          <h2>Install Ubuntu Core</h2>
-          <p>We will walk you through the steps of flashing Ubuntu Core on a Raspberry Pi 2 or 3. At the end of this process, you will have a board ready for production or testing snaps.</p>
+          <h2>Install Ubuntu Server</h2>
+          <p>We will walk you through the steps of flashing Ubuntu Server on a Raspberry Pi 2 or 3. At the end of this process, you will have a fully fledged development or production environment..</p>
         </div>
         <div class="col-6 p-divider__block">
           <h3>Minimum requirements</h3>
           <ul class="p-list">
             <li class="p-list__item is-ticked">A Raspberry Pi 2 or 3</li>
             <li class="p-list__item is-ticked">A microSD card</li>
-            <li class="p-list__item is-ticked">An Ubuntu Core image</li>
+            <li class="p-list__item is-ticked">An Ubuntu Server image</li>
             <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
             <li class="p-list__item is-ticked">An HDMI cable</li>
             <li class="p-list__item is-ticked">A USB keyboard</li>
@@ -40,28 +43,27 @@
     <div class="col-12">
       <h2>Installation instructions</h2>
       <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" with number=1 %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
-            Download Ubuntu Core
+            <span class="p-list-step__bullet">1</span>
+            Download Ubuntu Server
           </h3>
           <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
+            <p>Get the correct Ubuntu Server image for your board:</p>
             <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Ubuntu Core 18 image for Raspberry Pi 2.</a>
+              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/ubuntu-{{ lts_release_with_point }}-preinstalled-server-armhf+raspi2.img.xz">Ubuntu Server image for Raspberry Pi 2.</a>
               </li>
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz">Ubuntu Core 18 image for Raspberry Pi 3.</a></li>
-              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
+              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/ubuntu-{{ lts_release_with_point }}-preinstalled-server-arm64+raspi3.img.xz">Ubuntu Server image for Raspberry Pi 3</a></li>
+              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
               </li>
             </ul>
           </div>
         </li>
-        {% include "./_flash-image.html" with card="microSD card" number=3 %}
+        {% include "./_flash-image.html" with card="microSD card" number=2 %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
-            Install Ubuntu Core
+            <span class="p-list-step__bullet">3</span>
+            Install Ubuntu Server
           </h3>
           <div class="p-list-step__content">
             <ol class="u-no-margin--left">
@@ -70,14 +72,47 @@
             </ol>
           </div>
         </li>
-        {% include "./_first-boot-setup.html" with number=5 %}
-        {% include "./_login.html" with number=6 %}
+        {% include "./_login.html" with number=4 %}
       </ol>
     </div>
   </div>
 </section>
 
-{% include "./_boot-tips-strip.html" with strip="p-strip--light" %}
+<section class="p-strip--light is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h3>First boot tips</h3>
+      <ul>
+        <li>You can install a desktop if you like, here are some popular ones:
+          <ul>
+            <li>
+              <div class="p-code-snippet">
+                <input class="p-code-snippet__input" value="sudo apt-get install xubuntu-desktop" readonly="readonly">
+                <button class="p-code-snippet__action">Copy to clipboard</button>
+              </div>
+            </li>
+            <li>
+              <div class="p-code-snippet">
+                <input class="p-code-snippet__input" value="sudo apt-get install lubuntu-desktop" readonly="readonly">
+                <button class="p-code-snippet__action">Copy to clipboard</button>
+              </div>
+            </li>
+            <li>
+              <div class="p-code-snippet">
+                <input class="p-code-snippet__input" value="sudo apt-get install kubuntu-desktop" readonly="readonly">
+                <button class="p-code-snippet__action">Copy to clipboard</button>
+              </div>
+            </li>
+          </ul>
+        </li>
+        <li>For more details about Raspberry Pi specific packages included with this image and further customisations, such as accelerated video drivers and optional PPAs, you can refer to the <a class="p-link--external" href="https://wiki.ubuntu.com/ARM/RaspberryPi#Packages">RaspberryPi wiki</a>.</li>
+      </ul>
+    </div>
+    <div class="col-4 u-hide--small u-align--center u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}e2047558-pictogram-knowledge-orange-white-background.svg" alt="" width="180">
+    </div>
+  </div>
+</section>
 
 {% include "./_install-snaps-strip.html" %}
 

--- a/templates/download/iot/raspberry-pi-2-3.html
+++ b/templates/download/iot/raspberry-pi-2-3.html
@@ -4,14 +4,14 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit#{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--light is-bordered">
+<section class="p-strip is-bordered">
   <div class="row">
     <div class="col-8">
       <div>
         <h1>Install Ubuntu Server on a Raspberry Pi 2 or 3</h1>
       </div>
     </div>
-    <div class="col-4 u-vertically-center u-align--center">
+    <div class="col-4 u-vertically-center">
       <img src="{{ ASSET_SERVER_URL }}31bd2627-logo-raspberry-pi.svg" width="100" alt="Raspberry Pi">
     </div>
   </div>
@@ -38,7 +38,7 @@
   </div>
 </section>
 
-<section class="p-strip is-deep is-bordered">
+<section class="p-strip--light is-deep is-bordered">
   <div class="row">
     <div class="col-12">
       <h2>Installation instructions</h2>
@@ -50,7 +50,7 @@
           </h3>
           <div class="p-list-step__content">
             <p>Get the correct Ubuntu Server image for your board:</p>
-            <ul class="u-no-margin--left">
+            <ul class="u-no-margin--left" style="list-style-type: disc;">
               <li><a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/ubuntu-{{ lts_release_with_point }}-preinstalled-server-armhf+raspi2.img.xz">Ubuntu Server image for Raspberry Pi 2.</a>
               </li>
               <li><a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/ubuntu-{{ lts_release_with_point }}-preinstalled-server-arm64+raspi3.img.xz">Ubuntu Server image for Raspberry Pi 3</a></li>
@@ -72,49 +72,43 @@
             </ol>
           </div>
         </li>
-        {% include "./_login.html" with number=4 %}
+        <li class="p-list-step__item">
+          <h3 class="p-list-step__title">
+            <span class="p-list-step__bullet">4</span>
+            Login
+          </h3>
+          <div class="p-list-step__content">
+            <p>When prompted to log in, use "ubuntu" for the username and the password. You will be asked to change this default password after you log in.</p>
+          </div>
+        </li>
       </ol>
     </div>
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip is-bordered">
   <div class="row u-equal-height">
     <div class="col-8">
       <h3>First boot tips</h3>
-      <ul>
-        <li>You can install a desktop if you like, here are some popular ones:
-          <ul>
-            <li>
-              <div class="p-code-snippet">
-                <input class="p-code-snippet__input" value="sudo apt-get install xubuntu-desktop" readonly="readonly">
-                <button class="p-code-snippet__action">Copy to clipboard</button>
-              </div>
-            </li>
-            <li>
-              <div class="p-code-snippet">
-                <input class="p-code-snippet__input" value="sudo apt-get install lubuntu-desktop" readonly="readonly">
-                <button class="p-code-snippet__action">Copy to clipboard</button>
-              </div>
-            </li>
-            <li>
-              <div class="p-code-snippet">
-                <input class="p-code-snippet__input" value="sudo apt-get install kubuntu-desktop" readonly="readonly">
-                <button class="p-code-snippet__action">Copy to clipboard</button>
-              </div>
-            </li>
-          </ul>
-        </li>
-        <li>For more details about Raspberry Pi specific packages included with this image and further customisations, such as accelerated video drivers and optional PPAs, you can refer to the <a class="p-link--external" href="https://wiki.ubuntu.com/ARM/RaspberryPi#Packages">RaspberryPi wiki</a>.</li>
-      </ul>
-    </div>
-    <div class="col-4 u-hide--small u-align--center u-vertically-center">
-      <img src="{{ ASSET_SERVER_URL }}e2047558-pictogram-knowledge-orange-white-background.svg" alt="" width="180">
+      <p>You can install a desktop if you like, here are some popular ones:</p>
+          <div class="p-code-snippet">
+            <input class="p-code-snippet__input" value="sudo apt-get install xubuntu-desktop" readonly="readonly">
+            <button class="p-code-snippet__action">Copy to clipboard</button>
+          </div>
+          <div class="p-code-snippet">
+            <input class="p-code-snippet__input" value="sudo apt-get install lubuntu-desktop" readonly="readonly">
+            <button class="p-code-snippet__action">Copy to clipboard</button>
+          </div>
+          <div class="p-code-snippet">
+            <input class="p-code-snippet__input" value="sudo apt-get install kubuntu-desktop" readonly="readonly">
+            <button class="p-code-snippet__action">Copy to clipboard</button>
+          </div>
+        <p>For more details about Raspberry Pi specific packages included with this image and further customisations, such as accelerated video drivers and optional package repositories, you can refer to the <a class="p-link--external" href="https://wiki.ubuntu.com/ARM/RaspberryPi#Packages">RaspberryPi wiki</a>.</p>
     </div>
   </div>
 </section>
 
-{% include "./_install-snaps-strip.html" %}
+{% include "./_install-snaps-strip.html" with strip="p-strip--light" %}
 
 {% include "download/shared/_get-ebook-security.html"%}
 

--- a/templates/download/iot/raspberry-pi-2-3.html
+++ b/templates/download/iot/raspberry-pi-2-3.html
@@ -91,19 +91,19 @@
     <div class="col-8">
       <h3>First boot tips</h3>
       <p>You can install a desktop if you like, here are some popular ones:</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="sudo apt-get install xubuntu-desktop" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
-          </div>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="sudo apt-get install lubuntu-desktop" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
-          </div>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="sudo apt-get install kubuntu-desktop" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
-          </div>
-        <p>For more details about Raspberry Pi specific packages included with this image and further customisations, such as accelerated video drivers and optional package repositories, you can refer to the <a class="p-link--external" href="https://wiki.ubuntu.com/ARM/RaspberryPi#Packages">RaspberryPi wiki</a>.</p>
+      <div class="p-code-snippet">
+        <input class="p-code-snippet__input" value="sudo apt-get install xubuntu-desktop" readonly="readonly">
+        <button class="p-code-snippet__action">Copy to clipboard</button>
+      </div>
+      <div class="p-code-snippet">
+        <input class="p-code-snippet__input" value="sudo apt-get install lubuntu-desktop" readonly="readonly">
+        <button class="p-code-snippet__action">Copy to clipboard</button>
+      </div>
+      <div class="p-code-snippet">
+        <input class="p-code-snippet__input" value="sudo apt-get install kubuntu-desktop" readonly="readonly">
+        <button class="p-code-snippet__action">Copy to clipboard</button>
+      </div>
+      <p>For more details about Raspberry Pi specific packages included with this image and further customisations, such as accelerated video drivers and optional package repositories, you can refer to the <a class="p-link--external" href="https://wiki.ubuntu.com/ARM/RaspberryPi#Packages">RaspberryPi wiki</a>.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Server version of raspberry pi page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/iot/raspberry-pi-2-3](http://0.0.0.0:8001/download/iot/raspberry-pi-2-3)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit#)

## Issue / Card

Fixes #4955

