### PR TITLE
Update alternative downloads for 19.04

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -1,7 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Alternative downloads{% endblock %}
-{% block meta_description %}Want to download via-bitTorrent links, get DVD images with more language packs, use the text-based alternate installer or find previous versions of Ubuntu?{% endblock %}
+{% block meta_description %}Want to download via-bitTorrent links, get images with more language packs, use the text-based alternate installer or find previous versions of Ubuntu?{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit{% endblock meta_copydoc %}
 
 {% block content %}
@@ -9,7 +9,7 @@
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>Alternative downloads</h1>
-      <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional DVD image mirrors for our older (and newer) releases. If you don&rsquo;t specifically require any of these installers, we recommend using our <a href="/download">default installers</a>.</p>
+      <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional mirrors for our older (and newer) releases. If you don&rsquo;t specifically require any of these installers, we recommend using our <a href="/download">standard downloads</a>.</p>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" width="200" height="200" alt="" />
@@ -37,7 +37,7 @@
   <div class="row" id="bittorrents">
     <div class="col-8">
       <h2 id="bittorrent">BitTorrent</h2>
-      <p>BitTorrent is a peer-to-peer download network that sometimes enables higher download speeds and more reliable downloads of large files. You will need to install a BitTorrent client on your computer in order to enable this download method.</p>
+      <p>BitTorrent is a peer-to-peer download network that sometimes enables higher download speeds and more reliable downloads of large files. You need a BitTorrent client on your computer to enable this download method.</p>
     </div>
   </div>
 
@@ -81,12 +81,12 @@
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
       <h2 id="alternate-ubuntu-server-installer">Alternative Ubuntu Server installer</h2>
-      <p>If you require advanced networking and storage features such as; LVM, RAID, multipath, vlans, bonds, or re-using existing partitions, you will want to continue to use the alternate installer.</p>
+      <p>If you require advanced networking and storage features such as LVM, RAID, multipath, vlans, bonds, or reusing existing partitions, you will want to continue to use the alternate installer.</p>
       <p><a href="http://cdimage.ubuntu.com/releases/{{ lts_release_with_point }}/release/" class="p-link--external">Download the alternate installer</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h2 id="other-images-and-mirrors">Other images and mirrors</h2>
-      <p>For other versions of the Ubuntu installer please select your nearest mirror; however, we recommend you use  the <a href="/download">standard installer</a> as all other packages are available in Ubuntu Software Centre.</p>
+      <p>For the full list of available Ubuntu images, we recommend you select a mirror local to you.</p>
       <p><a href="https://launchpad.net/ubuntu/+cdmirrors" class="p-link--external">See all Ubuntu mirrors</a></p>
     </div>
     <div class="col-4 p-divider__block">


### PR DESCRIPTION
## Done

- Updated the /download/alternative-downloads page

**NOTE: until the template variables are merged, this page will not look 100% correct**

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/alternative-downloads](http://0.0.0.0:8001/download/alternative-downloads)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit#)


## Issue / Card

Fixes #4929