### PR TITLE
Update /server page for 19.04

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -56,15 +56,14 @@
       <h2>What&rsquo;s new in {{latest_release}}</h2>
       <ul class="p-list is-split">
         <li class="p-list__item is-ticked">Supported by Canonical for 9 months</li>
-        <li class="p-list__item is-ticked">Runs on all major architectures – x86, x86-64, ARM v7, ARM64, POWER8, POWER9, and IBM s390x (LinuxONE)</li>
-        <li class="p-list__item is-ticked">Updated installer with advanced networking support (e.g. bridges, bonds, and vlans) and storage support (e.g. LVM, mdadm etc)</li>
-        <li class="p-list__item is-ticked">Linux 4.18 kernel</li>
-        <li class="p-list__item is-ticked">Updates to LXD (v3.5), qemu (v2.12) and more</li>
-        <li class="p-list__item is-ticked">NVDIMM support added</li>
+        <li class="p-list__item is-ticked">Linux 5.0 kernel</li>
+        <li class="p-list__item is-ticked">Updates to LXD (v3.12), qemu (v3.1), dpdk (v18.11) and more</li>
+        <li class="p-list__item is-ticked">Fresh set of fixes and refreshes to the Ubuntu Server installer</li>
+        <li class="p-list__item is-ticked">New Ubuntu Advantage experience</li>
       </ul>
       <p><a class="p-link--external"
-        href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes">Read more in the release notes
-      </a></p>
+        href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes">Read more in the release notes</a>
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Udated the what's new section of the server overview

**Note: page will not look 100% correct until the template variables are merged**

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/server](http://0.0.0.0:8001/server)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [copy doc](https://docs.google.com/document/d/1vxLhtbjgPs9PCNEhr7fbhEoErCPMXYFfU4UTKH7Kbq4/edit#)


## Issue / Card

Fixes #4927

## Screenshots

![image](https://user-images.githubusercontent.com/441217/56096242-8d205300-5edd-11e9-853f-54f5c0f59cb3.png)
