### PR TITLE
Make takeovers visible on mobile

### DIFF
--- a/templates/takeovers/_fin-serv-whitepaper-takeover.html
+++ b/templates/takeovers/_fin-serv-whitepaper-takeover.html
@@ -16,6 +16,7 @@
     <style>
       .p-takeover--fin-serv-whitepaper {
         background-blend-mode: color;
+        background-color: #2C001E;
         background-image: linear-gradient(-45deg, #5E2750 0%, #2C001E 100%);
       }
 

--- a/templates/takeovers/_snap-deltas-takeover.html
+++ b/templates/takeovers/_snap-deltas-takeover.html
@@ -14,6 +14,7 @@
     <style>
       .p-takeover--snap-deltas {
         background-blend-mode: color;
+        background-color: #083333;
         background-image: linear-gradient(-181deg, #106363 12%, #083333 100%);
       }
 


### PR DESCRIPTION
## Done
Add fall back background colors to the takeovers that only have linear-gradients.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Load the demo on your phone (Android, Chrome)
- Check that the "Optimising IoT bandwidth with delta updates" and "Transforming financial services with multi-cloud" takeovers have backgrounds set

## Issue / Card
Fixes https://github.com/canonical-websites/www.ubuntu.com/issues/4964
