### PR TITLE
added 19.04-takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -35,8 +35,8 @@
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
   {% include "takeovers/_1904-takeover.html" %}
-  <!-- {% include "takeovers/_ci-cd-webinar.html" %}
+  {% include "takeovers/_ci-cd-webinar.html" %}
   {% include "takeovers/_14-04-esm.html" %}
   {% include "takeovers/_snap-deltas-takeover.html" %}
-  {% include "takeovers/_fin-serv-whitepaper-takeover.html" %} -->
+  {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
 {% endblock takeover_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,9 +35,8 @@
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
   {% include "takeovers/_1904-takeover.html" %}
-  {% include "takeovers/_ci-cd-webinar.html" %}
+  <!-- {% include "takeovers/_ci-cd-webinar.html" %}
   {% include "takeovers/_14-04-esm.html" %}
   {% include "takeovers/_snap-deltas-takeover.html" %}
-  {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
+  {% include "takeovers/_fin-serv-whitepaper-takeover.html" %} -->
 {% endblock takeover_content %}
-

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,8 +34,10 @@
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
+  {% include "takeovers/_1904-takeover.html" %}
   {% include "takeovers/_ci-cd-webinar.html" %}
   {% include "takeovers/_14-04-esm.html" %}
   {% include "takeovers/_snap-deltas-takeover.html" %}
   {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
 {% endblock takeover_content %}
+

--- a/templates/takeovers/_1904-takeover.html
+++ b/templates/takeovers/_1904-takeover.html
@@ -20,8 +20,8 @@
             <a
               href="https://www.brighttalk.com/webcast/6793/354804?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
               onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'Register for the webinar', 'eventValue' : undefined });"
-              class="p-link--inverted"
-              >Register for the webinar&nbsp;›</a
+              class="p-link--inverted p-link--external"
+              >Register for the webinar</a
             >
           </li>
         </ul>
@@ -45,8 +45,8 @@
           <a
             href="https://www.brighttalk.com/webcast/6793/354804?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'Register for the webinar', 'eventValue' : undefined });"
-            class="p-link--inverted"
-            >Register for the webinar&nbsp;›</a
+            class="p-link--inverted p-link--external"
+            >Register for the webinar</a
           >
         </p>
       </div>
@@ -69,7 +69,7 @@
     }
 
     .p-takeover__image {
-      opacity: 0.4;
+      mix-blend-mode: overlay;
     }
 
     @media (max-width: 874px) {
@@ -84,6 +84,13 @@
       }
       .p-takeover__image {
         width: 188px;
+      }
+    }
+
+    @media (max-width: 620px) {
+      .p-takeover__image {
+        opacity: 0.4;
+        mix-blend-mode: normal;
       }
     }
   </style>

--- a/templates/takeovers/_1904-takeover.html
+++ b/templates/takeovers/_1904-takeover.html
@@ -7,14 +7,24 @@
           From the Linux Kernel to Openstack and Kubernetes: find out why the
           latest Ubuntu release is our most advanced to date.
         </p>
-        <p>
-          <a
-            href="/download"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'What’s new in Ubuntu 19.04?', 'eventValue' : undefined });"
-            class="p-button--neutral u-hide--small"
-            ><span>Download Ubuntu</span></a
-          >
-        </p>
+        <ul class="p-inline-list u-hide--small">
+          <li class="p-inline-list__item">
+            <a
+              href="/download"
+              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'What’s new in Ubuntu 19.04?', 'eventValue' : undefined });"
+              class="p-button--neutral"
+              ><span>Download Ubuntu</span></a
+            >
+          </li>
+          <li class="p-inline-list__item">
+            <a
+              href="https://www.brighttalk.com/webcast/6793/354804?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
+              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'Register for the webinar', 'eventValue' : undefined });"
+              class="p-link--inverted"
+              >Register for the webinar&nbsp;›</a
+            >
+          </li>
+        </ul>
       </div>
       <div class="col-4">
         <p class="p-takeover__image u-align-text--center">
@@ -23,12 +33,20 @@
             alt=""
           />
         </p>
-        <p>
+        <p class="u-hide--medium u-hide--large">
+          <a
+            href="/download"
+            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'What’s new in Ubuntu 19.04?', 'eventValue' : undefined });"
+            class="p-button--neutral"
+            ><span>Download Ubuntu</span></a
+          >
+        </p>
+        <p class="u-hide--medium u-hide--large">
           <a
             href="https://www.brighttalk.com/webcast/6793/354804?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'What’s new in Ubuntu 19.04?', 'eventValue' : undefined });"
-            class="p-button--neutral u-hide--large u-hide--medium"
-            ><span class="p-link--external">Register for the webinar</span></a
+            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'Register for the webinar', 'eventValue' : undefined });"
+            class="p-link--inverted"
+            >Register for the webinar&nbsp;›</a
           >
         </p>
       </div>
@@ -48,6 +66,10 @@
       background-position: left, right;
       background-repeat: no-repeat, no-repeat;
       background-size: auto 100%, auto 100%, cover;
+    }
+
+    .p-takeover__image {
+      opacity: 0.4;
     }
 
     @media (max-width: 874px) {

--- a/templates/takeovers/_1904-takeover.html
+++ b/templates/takeovers/_1904-takeover.html
@@ -1,0 +1,38 @@
+<section class="p-strip--dark p-takeover js-takeover" >
+    <div class="row">
+      <div class="p-takeover__body u-clearfix u-vertically-center">
+        <div class="col-8">
+          <h1 class="p-takeover__title">What’s new in Ubuntu 19.04?</h1>
+          <p class="p-heading--four u-no-margin--right">Learn how the latest Ubuntu release is making new open source software accessible to developers and innovators.</p>
+          <p><a href="/download" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '18.04 takeover', 'eventLabel' : 'Download 18.04 now', 'eventValue' : undefined });" class="p-button--neutral u-hide--small"><span>Register for the webinar</span></a></p>
+        </div>
+        <div class="col-4">
+            <p class="p-takeover__image u-align-text--center">
+                <img src="{{ ASSET_SERVER_URL }}a76865fa-disco_dingo_mascot.svg" alt="">
+            </p>
+            <p><a href="/download" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '18.04 takeover', 'eventLabel' : 'Download 18.04 now', 'eventValue' : undefined });" class="p-button--neutral u-hide--large u-hide--medium"><span>Register for the webinar</span></a></p>
+        </div>
+      </div>
+    </div>
+    <style>
+    .p-takeover {
+        background-image: url('{{ ASSET_SERVER_URL }}8951dc67-suru-left.svg'), url('{{ ASSET_SERVER_URL }}55079ac4-suru-right.svg'),linear-gradient(0deg, #DD4814 0%, #BE3D2F 23%, #76236D 75%, #531A4D 100%);
+        background-position: left, right;
+        background-repeat: no-repeat, no-repeat;
+        background-size: auto 100%, auto 100%, cover;
+    }
+
+    .p-takeover__image {
+        mix-blend-mode: overlay;
+    }
+
+    @media (max-width: 874px) { 
+        .p-takeover {
+            background-image: linear-gradient(0deg, #DD4814 0%, #B83B34 22%, #76236D 60%, #531A4D 100%);
+        }
+          .p-takeover__image {
+            width:188px;
+          }
+        }  
+    </style>
+  </section>

--- a/templates/takeovers/_1904-takeover.html
+++ b/templates/takeovers/_1904-takeover.html
@@ -4,13 +4,13 @@
         <div class="col-8">
           <h1 class="p-takeover__title">What’s new in Ubuntu 19.04?</h1>
           <p class="p-heading--four u-no-margin--right">Learn how the latest Ubuntu release is making new open source software accessible to developers and innovators.</p>
-          <p><a href="/download" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '18.04 takeover', 'eventLabel' : 'Download 18.04 now', 'eventValue' : undefined });" class="p-button--neutral u-hide--small"><span>Register for the webinar</span></a></p>
+          <p><a href="/download" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'What’s new in Ubuntu 19.04?', 'eventValue' : undefined });" class="p-button--neutral u-hide--small"><span>Download Ubuntu</span></a></p>
         </div>
         <div class="col-4">
             <p class="p-takeover__image u-align-text--center">
                 <img src="{{ ASSET_SERVER_URL }}a76865fa-disco_dingo_mascot.svg" alt="">
             </p>
-            <p><a href="/download" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '18.04 takeover', 'eventLabel' : 'Download 18.04 now', 'eventValue' : undefined });" class="p-button--neutral u-hide--large u-hide--medium"><span>Register for the webinar</span></a></p>
+            <p><a href="https://www.brighttalk.com/webcast/6793/354804?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_19.04_WBN_19.04" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'What’s new in Ubuntu 19.04?', 'eventValue' : undefined });" class="p-button--neutral u-hide--large u-hide--medium"><span class="p-link--external">Register for the webinar</span></a></p>
         </div>
       </div>
     </div>

--- a/templates/takeovers/_1904-takeover.html
+++ b/templates/takeovers/_1904-takeover.html
@@ -18,7 +18,7 @@
           </li>
           <li class="p-inline-list__item">
             <a
-              href="https://www.brighttalk.com/webcast/6793/354804?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
+              href="/engage/19-04-webinar?utm_source=takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
               onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'Register for the webinar', 'eventValue' : undefined });"
               class="p-link--inverted p-link--external"
               >Register for the webinar</a
@@ -43,7 +43,7 @@
         </p>
         <p class="u-hide--medium u-hide--large">
           <a
-            href="https://www.brighttalk.com/webcast/6793/354804?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
+            href="/engage/19-04-webinar?utm_source=takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'Register for the webinar', 'eventValue' : undefined });"
             class="p-link--inverted p-link--external"
             >Register for the webinar</a

--- a/templates/takeovers/_1904-takeover.html
+++ b/templates/takeovers/_1904-takeover.html
@@ -1,38 +1,68 @@
-<section class="p-strip--dark p-takeover js-takeover" >
-    <div class="row">
-      <div class="p-takeover__body u-clearfix u-vertically-center">
-        <div class="col-8">
-          <h1 class="p-takeover__title">What’s new in Ubuntu 19.04?</h1>
-          <p class="p-heading--four u-no-margin--right">Learn how the latest Ubuntu release is making new open source software accessible to developers and innovators.</p>
-          <p><a href="/download" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'What’s new in Ubuntu 19.04?', 'eventValue' : undefined });" class="p-button--neutral u-hide--small"><span>Download Ubuntu</span></a></p>
-        </div>
-        <div class="col-4">
-            <p class="p-takeover__image u-align-text--center">
-                <img src="{{ ASSET_SERVER_URL }}a76865fa-disco_dingo_mascot.svg" alt="">
-            </p>
-            <p><a href="https://www.brighttalk.com/webcast/6793/354804?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_19.04_WBN_19.04" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'What’s new in Ubuntu 19.04?', 'eventValue' : undefined });" class="p-button--neutral u-hide--large u-hide--medium"><span class="p-link--external">Register for the webinar</span></a></p>
-        </div>
+<section class="p-strip--dark p-takeover js-takeover">
+  <div class="row">
+    <div class="p-takeover__body u-clearfix u-vertically-center">
+      <div class="col-8">
+        <h1 class="p-takeover__title">What’s new in Ubuntu 19.04?</h1>
+        <p class="p-heading--four u-no-margin--right">
+          From the Linux Kernel to Openstack and Kubernetes: find out why the
+          latest Ubuntu release is our most advanced to date.
+        </p>
+        <p>
+          <a
+            href="/download"
+            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'What’s new in Ubuntu 19.04?', 'eventValue' : undefined });"
+            class="p-button--neutral u-hide--small"
+            ><span>Download Ubuntu</span></a
+          >
+        </p>
+      </div>
+      <div class="col-4">
+        <p class="p-takeover__image u-align-text--center">
+          <img
+            src="{{ ASSET_SERVER_URL }}a76865fa-disco_dingo_mascot.svg"
+            alt=""
+          />
+        </p>
+        <p>
+          <a
+            href="https://www.brighttalk.com/webcast/6793/354804?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
+            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 takeover', 'eventLabel' : 'What’s new in Ubuntu 19.04?', 'eventValue' : undefined });"
+            class="p-button--neutral u-hide--large u-hide--medium"
+            ><span class="p-link--external">Register for the webinar</span></a
+          >
+        </p>
       </div>
     </div>
-    <style>
+  </div>
+  <style>
     .p-takeover {
-        background-image: url('{{ ASSET_SERVER_URL }}8951dc67-suru-left.svg'), url('{{ ASSET_SERVER_URL }}55079ac4-suru-right.svg'),linear-gradient(0deg, #DD4814 0%, #BE3D2F 23%, #76236D 75%, #531A4D 100%);
-        background-position: left, right;
-        background-repeat: no-repeat, no-repeat;
-        background-size: auto 100%, auto 100%, cover;
+      background-image: url("{{ ASSET_SERVER_URL }}8951dc67-suru-left.svg"),
+        url("{{ ASSET_SERVER_URL }}55079ac4-suru-right.svg"),
+        linear-gradient(
+          0deg,
+          #dd4814 0%,
+          #be3d2f 23%,
+          #76236d 75%,
+          #531a4d 100%
+        );
+      background-position: left, right;
+      background-repeat: no-repeat, no-repeat;
+      background-size: auto 100%, auto 100%, cover;
     }
 
-    .p-takeover__image {
-        mix-blend-mode: overlay;
+    @media (max-width: 874px) {
+      .p-takeover {
+        background-image: linear-gradient(
+          0deg,
+          #dd4814 0%,
+          #b83b34 22%,
+          #76236d 60%,
+          #531a4d 100%
+        );
+      }
+      .p-takeover__image {
+        width: 188px;
+      }
     }
-
-    @media (max-width: 874px) { 
-        .p-takeover {
-            background-image: linear-gradient(0deg, #DD4814 0%, #B83B34 22%, #76236D 60%, #531A4D 100%);
-        }
-          .p-takeover__image {
-            width:188px;
-          }
-        }  
-    </style>
-  </section>
+  </style>
+</section>


### PR DESCRIPTION
## Done

A new html file for 19.04-takeover was added.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to homepage and refresh the page until the 19.04 takeover appears.
- Make sure it matches the design
- Make sure it matches the copy doc https://docs.google.com/document/d/1z3PfG2SbTphLfbUMO9CyGbpYA5u9muBTCLxG8rRmZ7E/edit?ts=5cb5e731


## Issue / Card

 Fixes  https://github.com/canonical-web-and-design/web-squad/issues/1083



