### PR TITLE
Update to Django2

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,7 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn.gevent webapp.wsgi --bind $1 --worker-class gevent --name talisker-`hostname`"
+RUN_COMMAND="talisker.gunicorn webapp.wsgi --bind $1 --worker-class sync --name talisker-`hostname` --workers 5"
 
 if [ "${DJANGO_DEBUG}" = true ] || [ "${DJANGO_DEBUG}" = 1 ]; then
     echo ""

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -720,6 +720,7 @@ certification(?P<page>(/.*)?): "https://certification.ubuntu.com{page}"
 usn/?: "https://usn.ubuntu.com/"
 usn/rss\.xml: "https://usn.ubuntu.com/rss.xml"
 (?P<page>.*)\.html: "/{page}"
+(?P<page>.+)/: "/{page}"
 telco/?: "/telecommunications"
 telcos/?: "/telecommunications"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ canonicalwebteam.http==0.1.6
 whitenoise==4.1.2
 statsd==3.3.0
 prometheus_client==0.6.0
-talisker[gunicorn]==0.14.2
+talisker[gunicorn]==0.14.3
 django-yaml-redirects==0.5.4
 django-asset-server-url==0.1
 django-static-root-finder==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,9 @@ canonicalwebteam.yaml-responses[django]==1.1.0
 canonicalwebteam.get-feeds==0.2.4
 canonicalwebteam.http==0.1.6
 whitenoise==4.1.2
-gunicorn[gevent]
 statsd==3.3.0
 prometheus_client==0.6.0
-talisker==0.14.2
+talisker[gunicorn]==0.14.2
 django-yaml-redirects==0.5.4
 django-asset-server-url==0.1
 django-static-root-finder==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.20
+Django==2.2
 django-prometheus==1.0.15
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.versioned_static==1.0.2
@@ -14,7 +14,6 @@ talisker==0.14.2
 django-yaml-redirects==0.5.4
 django-asset-server-url==0.1
 django-static-root-finder==0.3.1
-django-unslashed==0.3.0
 feedparser==5.2.1
 requests==2.21.0
 requests-cache==0.4.13

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -108,10 +108,6 @@ TEMPLATES = [
 
 ASSET_SERVER_URL = "https://assets.ubuntu.com/v1/"
 
-DATABASES = {
-    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "dummydb"}
-}
-
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -132,3 +128,5 @@ LOGGING = {
         }
     },
 }
+
+TESTRUNNER = "app.testrunner.NoDbTestRunner"

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -55,7 +55,6 @@ USE_TZ = False
 STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 APPEND_SLASH = False
-REMOVE_SLASH = True
 
 # Use the IP address for now, as Docker doesn't use the
 # VPN DNS server
@@ -66,21 +65,18 @@ REMOVE_SLASH = True
 SEARCH_SERVER_URL = "http://10.22.112.8/search"
 SEARCH_TIMEOUT = 10
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "canonicalwebteam.custom_response_headers.Middleware",
-    "unslashed.middleware.RemoveSlashMiddleware",
 ]
 
 # Prometheus
 if not DEBUG:
     INSTALLED_APPS.append("django_prometheus")
-    MIDDLEWARE_CLASSES.insert(
+    MIDDLEWARE.insert(
         0, "django_prometheus.middleware.PrometheusBeforeMiddleware"
     )
-    MIDDLEWARE_CLASSES.append(
-        "django_prometheus.middleware.PrometheusAfterMiddleware"
-    )
+    MIDDLEWARE.append("django_prometheus.middleware.PrometheusAfterMiddleware")
     # Run the prometheus exporters on a range of ports
     PROMETHEUS_METRICS_EXPORT_PORT_RANGE = range(9990, 9999)
 
@@ -111,6 +107,10 @@ TEMPLATES = [
 ]
 
 ASSET_SERVER_URL = "https://assets.ubuntu.com/v1/"
+
+DATABASES = {
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "dummydb"}
+}
 
 LOGGING = {
     "version": 1,

--- a/webapp/testrunner.py
+++ b/webapp/testrunner.py
@@ -1,0 +1,13 @@
+from django.test.runner import DiscoverRunner
+
+
+class NoDbTestRunner(DiscoverRunner):
+    """
+    A test runner to test without database creation/deletion
+    """
+
+    def setup_databases(self, **kwargs):
+        pass
+
+    def teardown_databases(self, old_config, **kwargs):
+        pass


### PR DESCRIPTION
## Done

- uses sync workers instead of gevent (https://docs.gunicorn.org/en/stable/design.html)
- upgrades to Django 2.2 LTS (https://www.djangoproject.com/weblog/2019/apr/01/django-22-released/)
- removes unsupported `django-unslashed` middleware
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/base-squad/issues/454


