### PR TITLE
Download mirror list on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "build-css": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' --no-map",
     "build-js-bundle": "webpack",
     "build": "yarn run build-css && yarn run build-js-bundle",
+    "get-mirrors": "./scripts/get-mirrors-rss",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'node_modules/vanilla-framework/scss/*.scss' -c 'yarn run build'",
-    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle static/js/build",
+    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle static/js/build etc/",
     "serve": "./entrypoint 0.0.0.0:${PORT}"
   },
   "husky": {

--- a/scripts/get-mirrors-rss
+++ b/scripts/get-mirrors-rss
@@ -12,10 +12,10 @@ XML_FILE=${PROJECT_DIR}/etc/ubuntu-mirrors-rss.xml
 
 mkdir -p ${PROJECT_DIR}/etc
 rm -f $TEST_FILE
-wget -q -O $TEST_FILE https://launchpad.net/ubuntu/+cdmirrors-rss
 
+curl https://launchpad.net/ubuntu/+cdmirrors-rss -o $TEST_FILE
 RESULT=$(grep "Ubuntu CD Mirrors Status" $TEST_FILE)
 
 if [ "$RESULT" ]; then
-     mv $TEST_FILE $XML_FILE
+    mv $TEST_FILE $XML_FILE
 fi

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -407,7 +407,7 @@ class DownloadView(UbuntuTemplateFinder):
 
         try:
             with open(mirrors_path) as rss:
-                mirrors = parse(rss).entries
+                mirrors = parse(rss.read()).entries
         except IOError:
             mirrors = []
 


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-web-and-design/base-squad/issues/459
Download mirror list at build time

## QA

- Check out this feature branch
- `./run`
- make sure new directory created with the list of mirrors: `$PROJECT/etc/ubuntu-mirrors-rss.xml`
- If you run again, the script **shouldn't** download again the mirrors
- `./run clean`
- Make sure `$PROJECT/etc/` is deleted
