### PR TITLE
Notices

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -173,9 +173,6 @@
         // For browsers that support <template> (all but IE), grab the template's ".content"
         takeovers = 'content' in takeovers ? takeovers.content: takeovers;
 
-        // get the users language and remove any extra detail suffix (e.g. -gb)
-        var language = getPrimaryParentLanguage();
-
         // First, select takeovers that don't specify a language and don't exclude the users language
         var takeoverSelectors = [".js-takeover:not([lang]).js-takeover:not([lang-skip*=" + language + "])"]
 

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -23,6 +23,9 @@
       </div>
     </section>
 
+    {% block notices_content %}
+    {% endblock notices_content %}
+
     <section class="p-strip is-deep is-bordered">
       {% include "shared/_insights_news_strip.html" with gtm_event_label="ubuntu.com homepage" %}
     </section>
@@ -142,6 +145,17 @@
 
         return language
       };
+
+      // get the users language and remove any extra detail suffix (e.g. -gb)
+      var language = getPrimaryParentLanguage();
+
+      // get notices matching the user language
+      notices = document.querySelectorAll(".notice[lang=" + language + "]");
+
+      // display only one matching notice
+      if (notices.length > 0) {
+        notices[0].classList.remove("u-hide")
+      }
 
       if (window.localStorage && window.sessionStorage) {
         /**

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -150,7 +150,7 @@
       var language = getPrimaryParentLanguage();
 
       // get notices matching the user language
-      notices = document.querySelectorAll(".notice[lang=" + language + "]");
+      var notices = document.querySelectorAll(".notice[lang=" + language + "]");
 
       // display only one matching notice
       if (notices.length > 0) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,8 +51,11 @@
 
   ## Example
 
-    A notice to let Japanese speaking users know that a localized website is available.
-    include "shared/_notice_default.html" with lang="fr" text="私たちの日本のウェブサイトを試してみてください" url="https://jp.ubuntu.com" icon="https://assets.ubuntu.com/v1/838316ab-cof-25x25.png
+    Let Japanese speaking users know that a localized website is available.
+    include "shared/_notice_default.html" with lang="ja" text="私たちの日本のウェブサイトを試してみてください" url="https://jp.ubuntu.com" icon="https://assets.ubuntu.com/v1/838316ab-cof-25x25.png"
+    
+    The French Ubuntu community is having a release party!
+    include "shared/_notice_default.html" with lang="fr" text="À Paris les 18 et 19 mai? Venez à l'Ubuntu Party!" url="https://ubuntu-paris.org/"
 #}
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -39,3 +39,24 @@
   {% include "takeovers/_snap-deltas-takeover.html" %}
   {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
 {% endblock takeover_content %}
+
+
+{#
+  # Creating notices
+
+  A notice is a single line of text, with a link and an optional icon and a language.
+  Only one notice per language will be visible to users.
+  They are useful when you want to notify a specific segment of our global audience
+  that something is available in their language.
+
+  ## Example
+
+    A notice to let Japanese speaking users know that a localized website is available.
+    include "shared/_notice_default.html" with lang="fr" text="私たちの日本のウェブサイトを試してみてください" url="https://jp.ubuntu.com" icon="https://assets.ubuntu.com/v1/838316ab-cof-25x25.png
+#}
+
+
+{% block notices_content %}
+  {% include "shared/_notice_default.html" with lang="ja" text="私たちの日本のウェブサイトを試してみてください" url="https://jp.ubuntu.com" icon="https://assets.ubuntu.com/v1/838316ab-cof-25x25.png" %}
+{% endblock notices_content %}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -57,6 +57,6 @@
 
 
 {% block notices_content %}
-  {% include "shared/_notice_default.html" with lang="ja" text="私たちの日本のウェブサイトを試してみてください" url="https://jp.ubuntu.com" icon="https://assets.ubuntu.com/v1/838316ab-cof-25x25.png" %}
+  {% include "shared/_notice_default.html" with lang="ja" text="私たちの日本のウェブサイトを試してみてください" url="https://jp.ubuntu.com" icon="https://assets.ubuntu.com/v1/8114528b-picto-ubuntu-orange.png" %}
 {% endblock notices_content %}
 

--- a/templates/shared/_notice_default.html
+++ b/templates/shared/_notice_default.html
@@ -4,6 +4,7 @@
       <p class="u-no-max-width p-heading--four u-no-margin--bottom u-vertically-center">
         {% if icon %}<img src="{{icon}}" alt="{{text}}" style="width:25px;"/>&nbsp;&nbsp;{% endif %}
         <a href="{{url}}" class="p-link--external">{{text}}</a>
+      </p>
     </div>
   </div>
 </section>

--- a/templates/shared/_notice_default.html
+++ b/templates/shared/_notice_default.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-12">
       <p class="u-no-max-width p-heading--four u-no-margin--bottom u-vertically-center">
-        {% if icon %}<img src="{{icon}}" alt="" />&nbsp;&nbsp;{% endif %}
+        {% if icon %}<img src="{{icon}}" alt="" style="width:25px;"/>&nbsp;&nbsp;{% endif %}
         <a href="{{url}}" class="p-link--external">{{text}}</a>
     </div>
   </div>

--- a/templates/shared/_notice_default.html
+++ b/templates/shared/_notice_default.html
@@ -1,0 +1,9 @@
+<section class="p-strip--light is-shallow notice u-hide" lang="{{lang}}">
+  <div class="row">
+    <div class="col-12">
+      <p class="u-no-max-width p-heading--four u-no-margin--bottom u-vertically-center">
+        {% if icon %}<img src="{{icon}}" alt="" />&nbsp;&nbsp;{% endif %}
+        <a href="{{url}}" class="p-link--external">{{text}}</a>
+    </div>
+  </div>
+</section>

--- a/templates/shared/_notice_default.html
+++ b/templates/shared/_notice_default.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-12">
       <p class="u-no-max-width p-heading--four u-no-margin--bottom u-vertically-center">
-        {% if icon %}<img src="{{icon}}" alt="" style="width:25px;"/>&nbsp;&nbsp;{% endif %}
+        {% if icon %}<img src="{{icon}}" alt="{{text}}" style="width:25px;"/>&nbsp;&nbsp;{% endif %}
         <a href="{{url}}" class="p-link--external">{{text}}</a>
     </div>
   </div>


### PR DESCRIPTION
## Done

* Add localized notices to homepage
* Japanese website notice

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Switch your browser language to Japanese, ensure you see a notice on the homepage, under the takeover, that takes you to jp.ubuntu.com

## Screenshots

![Screenshot from 2019-04-17 12-31-49](https://usercontent.irccloud-cdn.com/file/B2FWyO5T/Screenshot%20from%202019-04-17%2013-56-38.png)

