### PR TITLE
Add 19-04-webinar engage page

### DIFF
--- a/templates/engage/19-04-webinar.html
+++ b/templates/engage/19-04-webinar.html
@@ -8,7 +8,7 @@
 
 
 {% block content %}
-{% include "engage/shared/_header.html" with title="What's new in Ubuntu 19.04?" url="#register-section" cta="Watch the webinar" class="p-strip--dark p-takeover--19-04-webinar"%}
+{% include "engage/shared/_header.html" with title="What's new in Ubuntu 19.04?" subtitle="Join Canonical Product Director Stephan Fabel and Ubuntu Product Managers to discuss everything new in Ubuntu 19.04 ‘Disco Dingo’" url="#register-section" cta="Watch the webinar" class="p-strip--dark p-takeover--19-04-webinar"%}
 
 <section class="p-strip is-shallow is-bordered">
   <div class="row">

--- a/templates/engage/19-04-webinar.html
+++ b/templates/engage/19-04-webinar.html
@@ -1,0 +1,44 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Optimising IoT bandwidth with delta updates{% endblock %}
+
+{% block meta_description %}Learn how snap deltas' over-the-air updates are efficient and effective.{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1BzilE80HtJ89mPXnhkaK0AYyYuPr8fnJPwnVUaMhJ9Y/edit#t{% endblock meta_copydoc %}
+
+
+{% block content %}
+{% include "engage/shared/_header.html" with title="With the release of Ubuntu 19.04" url="#register-section" cta="Watch the webinar" class="p-strip--dark p-takeover--19-04-webinar"%}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+      <p>Our most advanced release to date offers developers and innovators the first chance to experience the latest open source software available including the Linux 5.0 Kernel, OpenStack Stein, Kubernetes version 1.14 and Ceph Mimic.</p>
+
+      <p>Join our upcoming webinar hosted by Canonical Product Director, Stephan Fabel and Ubuntu Product Managers to learn about all the above and more, including what productivity updates have been made to existing features. In this webinar you will learn about:    
+      </p>
+
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Delivering open infrastructure deployments using Ubuntu Server 19.04</li>
+        <li class="p-list__item is-ticked">The various projects that make Ubuntu 19.04: Kubernetes 1.14, Openstack Stein, Ceph Mimic</li>
+        <li class="p-list__item is-ticked">How to use Ubuntu in IoT and embedded projects</li>
+        <li class="p-list__item is-ticked">The latest in Ubuntu Desktop 19.04</li>
+      </ul>
+
+      <p>
+        In addition to a product presentation, this will be the opportunity to ask Canonical’s product management team your questions about Ubuntu 19.04 Openstack Stein, Kubernetes 1.14 or Ceph Mimic.
+      </p>
+
+    </div>
+    <div class="col-5" id="register-section">
+      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 354804, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+    </div>
+  </div>
+</section>
+
+<style>
+  .p-takeover--19-04-webinar {
+    background-image: linear-gradient(0deg,#dd4814 0%,#be3d2f 23%,#76236d 75%,#531a4d 100%);
+  }
+</style>
+{% endblock content %}

--- a/templates/engage/19-04-webinar.html
+++ b/templates/engage/19-04-webinar.html
@@ -1,10 +1,10 @@
 {% extends "engage/base_engage.html" %}
 
-{% block title %}Optimising IoT bandwidth with delta updates{% endblock %}
+{% block title %}With the release of Ubuntu 19.04{% endblock %}
 
-{% block meta_description %}Learn how snap deltas' over-the-air updates are efficient and effective.{% endblock %}
+{% block meta_description %}Our most advanced release to date offers developers and innovators the first chance to experience the latest open source software available including the Linux 5.0 Kernel, OpenStack Stein, Kubernetes version 1.14 and Ceph Mimic.{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1BzilE80HtJ89mPXnhkaK0AYyYuPr8fnJPwnVUaMhJ9Y/edit#t{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1z3PfG2SbTphLfbUMO9CyGbpYA5u9muBTCLxG8rRmZ7E/edit#{% endblock meta_copydoc %}
 
 
 {% block content %}

--- a/templates/engage/19-04-webinar.html
+++ b/templates/engage/19-04-webinar.html
@@ -8,7 +8,7 @@
 
 
 {% block content %}
-{% include "engage/shared/_header.html" with title="With the release of Ubuntu 19.04" url="#register-section" cta="Watch the webinar" class="p-strip--dark p-takeover--19-04-webinar"%}
+{% include "engage/shared/_header.html" with title="What's new in Ubuntu 19.04?" url="#register-section" cta="Watch the webinar" class="p-strip--dark p-takeover--19-04-webinar"%}
 
 <section class="p-strip is-shallow is-bordered">
   <div class="row">

--- a/templates/engage/19-04-webinar.html
+++ b/templates/engage/19-04-webinar.html
@@ -10,35 +10,70 @@
 {% block content %}
 {% include "engage/shared/_header.html" with title="With the release of Ubuntu 19.04" url="#register-section" cta="Watch the webinar" class="p-strip--dark p-takeover--19-04-webinar"%}
 
-<section class="p-strip is-shallow">
+<section class="p-strip is-shallow is-bordered">
   <div class="row">
-    <div class="col-7">
-      <p>Our most advanced release to date offers developers and innovators the first chance to experience the latest open source software available including the Linux 5.0 Kernel, OpenStack Stein, Kubernetes version 1.14 and Ceph Mimic.</p>
-
-      <p>Join our upcoming webinar hosted by Canonical Product Director, Stephan Fabel and Ubuntu Product Managers to learn about all the above and more, including what productivity updates have been made to existing features. In this webinar you will learn about:    
-      </p>
-
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">Delivering open infrastructure deployments using Ubuntu Server 19.04</li>
-        <li class="p-list__item is-ticked">The various projects that make Ubuntu 19.04: Kubernetes 1.14, Openstack Stein, Ceph Mimic</li>
-        <li class="p-list__item is-ticked">How to use Ubuntu in IoT and embedded projects</li>
-        <li class="p-list__item is-ticked">The latest in Ubuntu Desktop 19.04</li>
-      </ul>
-
+    <div class="col-8">
       <p>
-        In addition to a product presentation, this will be the opportunity to ask Canonical’s product management team your questions about Ubuntu 19.04 Openstack Stein, Kubernetes 1.14 or Ceph Mimic.
+        Our most advanced release to date offers developers and innovators the
+        first chance to experience the latest open source software available
+        including the Linux 5.0 Kernel, OpenStack Stein, Kubernetes version 1.14
+        and Ceph Mimic.
       </p>
-
+      <p>
+        Join our upcoming webinar hosted by Canonical Product Director, Stephan
+        Fabel and Ubuntu Product Managers to learn about all the above and more,
+        including what productivity updates have been made to existing features.
+        In this webinar you will learn about:
+      </p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">
+          Delivering open infrastructure deployments using Ubuntu Server 19.04
+        </li>
+        <li class="p-list__item is-ticked">
+          The various projects that make Ubuntu 19.04: Kubernetes 1.14,
+          Openstack Stein, Ceph Mimic
+        </li>
+        <li class="p-list__item is-ticked">
+          How to use Ubuntu in IoT and embedded projects
+        </li>
+        <li class="p-list__item is-ticked">
+          The latest in Ubuntu Desktop 19.04
+        </li>
+      </ul>
+      <p>
+        In addition to a product presentation, this will be the opportunity to
+        ask Canonical’s product management team your questions about Ubuntu
+        19.04, Openstack Stein, Kubernetes 1.14 or Ceph Mimic.
+      </p>
     </div>
-    <div class="col-5" id="register-section">
-      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 354804, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+  </div>
+  <style>
+    .p-takeover--19-04-webinar {
+      background-image: linear-gradient(
+        0deg,
+        #dd4814 0%,
+        #be3d2f 23%,
+        #76236d 75%,
+        #531a4d 100%
+      );
+    }
+  </style>
+</section>
+
+<section class="p-strip is-shallow" id="register-section">
+  <div class="row" id="register-section">
+    <div
+      class="jsBrightTALKEmbedWrapper"
+      style="width:100%; height:100%; position:relative;background: #ffffff;"
+    >
+      <script class="jsBrightTALKEmbedConfig" type="application/json">
+        { "channelId" : 6793, "language": "en-US", "commId" : 354804, "displayMode" : "standalone", "height" : "auto" }</script
+      ><script
+        src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js"
+        class="jsBrightTALKEmbed"
+      ></script>
     </div>
   </div>
 </section>
 
-<style>
-  .p-takeover--19-04-webinar {
-    background-image: linear-gradient(0deg,#dd4814 0%,#be3d2f 23%,#76236d 75%,#531a4d 100%);
-  }
-</style>
 {% endblock content %}


### PR DESCRIPTION
## Done

Add 19-04-webinar engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/engage/19-04-webinar](http://0.0.0.0:8001/engage/19-04-webinar)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Make sure it matches the design
- Make sure it matches the [copy doc](https://docs.google.com/document/d/1z3PfG2SbTphLfbUMO9CyGbpYA5u9muBTCLxG8rRmZ7E/edit#) 



## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1083
