### PR TITLE
Hide all takeovers apart from 19.04

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -26,17 +26,17 @@
 
 {% block takeover_content %}
   {# GERMAN #}
-  {% include "takeovers/_german_ai_webinar.html" %}
-  {% include "takeovers/_german-compliance-webinar.html" %}
-  {% include "takeovers/_german_takeover_k8.html" %}
+  {# include "takeovers/_german_ai_webinar.html" #}
+  {# include "takeovers/_german-compliance-webinar.html" #}
+  {# include "takeovers/_german_takeover_k8.html" #}
   {# FRENCH #}
-  {% include "takeovers/_french-k8s-case-study.html" %}
-  {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
-  {% include "takeovers/_french_14-04-esm.html" %}
+  {# include "takeovers/_french-k8s-case-study.html" #}
+  {# include "takeovers/_french_takeover_openstack_made_easy.html" #}
+  {# include "takeovers/_french_14-04-esm.html" #}
   {# ALL #}
   {% include "takeovers/_1904-takeover.html" %}
-  {% include "takeovers/_ci-cd-webinar.html" %}
-  {% include "takeovers/_14-04-esm.html" %}
-  {% include "takeovers/_snap-deltas-takeover.html" %}
-  {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
+  {# include "takeovers/_ci-cd-webinar.html" #}
+  {# include "takeovers/_14-04-esm.html" #}
+  {# include "takeovers/_snap-deltas-takeover.html" #}
+  {# include "takeovers/_fin-serv-whitepaper-takeover.html" #}
 {% endblock takeover_content %}


### PR DESCRIPTION
## Done
Hide all takeovers apart from 19.04

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Go to homepage and see its just the 19.04 takeover
