### PR TITLE
Update alternative server installer text

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -81,8 +81,13 @@
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
       <h2 id="alternate-ubuntu-server-installer">Alternative Ubuntu Server installer</h2>
-      <p>If you require advanced networking and storage features such as LVM, RAID, multipath, vlans, bonds, or reusing existing partitions, you will want to continue to use the alternate installer.</p>
-      <p><a href="http://cdimage.ubuntu.com/releases/{{ lts_release_with_point }}/release/" class="p-link--external">Download the alternate installer</a></p>
+      <p>If you want to reuse your existing partitions, you will need to use the alternate installer.</p>
+      <p>
+        <a href="http://cdimage.ubuntu.com/releases/{{ lts_release_with_point }}/release/" class="p-link--external">Ubuntu {{lts_release_with_point}} alternate installer</a>
+      </p>
+      <p>
+        <a href="http://cdimage.ubuntu.com/releases/{{ latest_release_with_point }}/release/" class="p-link--external">Ubuntu {{latest_release_with_point}} alternate installer</a>
+      </p>
     </div>
     <div class="col-4 p-divider__block">
       <h2 id="other-images-and-mirrors">Other images and mirrors</h2>


### PR DESCRIPTION
## Done

- Updated the alternative server installer text and added 19.04

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/alternative-downloads](http://0.0.0.0:8001/download/alternative-downloads)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- [copy doc](https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit#)

## Screenshots

![image](https://user-images.githubusercontent.com/441217/56360842-b68ef680-61dd-11e9-9d8e-3e852cba9da5.png)

