### PR TITLE
Add lts to alt server installer link

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -83,10 +83,10 @@
       <h2 id="alternate-ubuntu-server-installer">Alternative Ubuntu Server installer</h2>
       <p>If you want to reuse your existing partitions, you will need to use the alternate installer.</p>
       <p>
-        <a href="http://cdimage.ubuntu.com/releases/{{ lts_release_with_point }}/release/" class="p-link--external">Ubuntu {{lts_release_with_point}} alternate installer</a>
+        <a href="http://cdimage.ubuntu.com/releases/{{ lts_release_with_point }}/release/" class="p-link--external">Ubuntu {{lts_release_full_with_point}} alternative installer</a>
       </p>
       <p>
-        <a href="http://cdimage.ubuntu.com/releases/{{ latest_release_with_point }}/release/" class="p-link--external">Ubuntu {{latest_release_with_point}} alternate installer</a>
+        <a href="http://cdimage.ubuntu.com/releases/{{ latest_release_with_point }}/release/" class="p-link--external">Ubuntu {{latest_release_with_point}} alternative installer</a>
       </p>
     </div>
     <div class="col-4 p-divider__block">


### PR DESCRIPTION
## Done

Add lts to alt server installer link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/alternative-downloads](http://0.0.0.0:8001/download/alternative-downloads)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- see that the alt server links read better

