### PR TITLE
CDK charm changes

### DIFF
--- a/templates/kubernetes/docs/aws-integration.md
+++ b/templates/kubernetes/docs/aws-integration.md
@@ -279,6 +279,6 @@ juju debug-log --replay --include aws-integrator/0
 [quickstart]: /kubernetes/docs/quickstart
 [storage]: /kubernetes/docs/storage
 [ebs-info]: https://aws.amazon.com/ebs/features/
-[cloudtrail]: console.aws.amazon.com/cloudtrail/
+[cloudtrail]: https://console.aws.amazon.com/cloudtrail/
 [bugs]: https://bugs.launchpad.net/charmed-kubernetes
 [aws-integrator-readme]: https://jujucharms.com/u/containers/aws-integrator/

--- a/templates/kubernetes/docs/aws-integration.md
+++ b/templates/kubernetes/docs/aws-integration.md
@@ -46,7 +46,7 @@ relations:
 To use this overlay with the **CDK** bundle, it is specified during deploy like this:
 
 ```bash
-juju deploy canonical-kubernetes  --overlay ~/path/aws-overlay.yaml
+juju deploy charmed-kubernetes  --overlay ~/path/aws-overlay.yaml
 ```
 
 Then run the command to share credentials with this charm:
@@ -279,6 +279,6 @@ juju debug-log --replay --include aws-integrator/0
 [quickstart]: /kubernetes/docs/quickstart
 [storage]: /kubernetes/docs/storage
 [ebs-info]: https://aws.amazon.com/ebs/features/
-[cloudtrail]: https://console.aws.amazon.com/cloudtrail/
+[cloudtrail]: console.aws.amazon.com/cloudtrail/
 [bugs]: https://bugs.launchpad.net/charmed-kubernetes
 [aws-integrator-readme]: https://jujucharms.com/u/containers/aws-integrator/

--- a/templates/kubernetes/docs/certs-and-trust.md
+++ b/templates/kubernetes/docs/certs-and-trust.md
@@ -84,7 +84,7 @@ can be used to provide additional names to be added to the SANs list.
 
 In order to provide for two-way security, some services require that clients
 identify themselves via a [client certificate][]. These are more or less the
-same as server certificates but are presented by a client to the service
+same as server certificates, but are presented by a client to the service
 they are connecting to so that the service can validate that client's identity.
 Client certificates can _only_ be used to identify a client and will be
 rejected by clients if presented by a service they are connecting to.
@@ -118,7 +118,6 @@ See the [operations documentation][vault-cdk] for details on how to deploy Vault
 
 
 
-[CDK]: http://jujucharms.com/canonical-kubernetes
 [TLS]: https://www.networkworld.com/article/2303073/lan-wan/lan-wan-what-is-transport-layer-security-protocol.html
 [PKI]: https://github.com/OpenVPN/easy-rsa/blob/master/doc/Intro-To-PKI.md
 [chain of trust]: https://en.wikipedia.org/wiki/Chain_of_trust

--- a/templates/kubernetes/docs/encryption-at-rest.md
+++ b/templates/kubernetes/docs/encryption-at-rest.md
@@ -48,7 +48,7 @@ To deploy **CDK** with this overlay - [download it][cdk-vault-overlay]), save it
 `cdk-vault-overlay.yaml`, and deploy with:
 
 ```
-juju deploy canonical-kubernetes --overlay cdk-vault-overlay.yaml
+juju deploy charmed-kubernetes --overlay cdk-vault-overlay.yaml
 ```
 
 Once **Vault** comes up (and any time it is rebooted), you will need to [unseal][]

--- a/templates/kubernetes/docs/gcp-integration.md
+++ b/templates/kubernetes/docs/gcp-integration.md
@@ -65,7 +65,7 @@ relations:
 To use this overlay with the **CDK** bundle, it is specified during deploy like this:
 
 ```bash
-juju deploy canonical-kubernetes --overlay ~/path/gcp-overlay.yaml
+juju deploy charmed-kubernetes --overlay ~/path/gcp-overlay.yaml
 ```
 
 Then run the command to share credentials with this charm:

--- a/templates/kubernetes/docs/gpu-workers.md
+++ b/templates/kubernetes/docs/gpu-workers.md
@@ -47,7 +47,7 @@ applications:
 And then deployed with CDK like this:
 
 ```bash
-juju deploy canonical-kubernetes --overlay ~/path/aws-overlay.yaml --overlay ~/path/gpu-overlay.yaml
+juju deploy charmed-kubernetes --overlay ~/path/aws-overlay.yaml --overlay ~/path/gpu-overlay.yaml
 ```
 
 As demonstrated here, you can use multiple overlay files when deploying, so you

--- a/templates/kubernetes/docs/hacluster.md
+++ b/templates/kubernetes/docs/hacluster.md
@@ -32,7 +32,7 @@ requires a minimum of 3 units for a quorum, so you will need 3 kubeapi-load-bala
 ### With Load Balancer
 
 ```bash
-juju deploy canonical-kubernetes
+juju deploy charmed-kubernetes
 juju add-unit -n 2 kubeapi-load-balancer
 juju deploy hacluster
 juju config kubeapi-load-balancer ha-cluster-vips=”192.168.0.1 192.168.0.2”

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -135,11 +135,7 @@ versions of the **CDK** bundle are shown in the table below:
 
 | Kubernetes version | CDK bundle |
 | --- | --- |
-<<<<<<< HEAD
 | 1.14.x         | [charmed-kubernetes-3](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-3/archive/bundle.yaml?channel=stable) |
-=======
-| 1.14.x         | [canonical-kubernetes-471](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-471/archive/bundle.yaml?channel=stable) |
->>>>>>> 08f2fb860d29e5b46c35fd706f995a65019f0a49
 | 1.13.x         | [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-435/archive/bundle.yaml?channel=stable) |
 | 1.12.x         | [canonical-kubernetes-357](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-357/archive/bundle.yaml?channel=stable) |
 | 1.11.x         | [canonical-kubernetes-254](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-254/archive/bundle.yaml?channel=stable) |

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -97,7 +97,7 @@ The **Juju Charm Store** hosts the **CDK** bundles as well as individual charms.
 deploy the latest, stable bundle, run the command:
 
 ```bash
-juju deploy canonical-kubernetes
+juju deploy charmed-kubernetes
 ```
 
 To get the status of the deployment, run `juju status`. For constant updates,
@@ -115,6 +115,17 @@ release, you could run:
 juju deploy cs:~containers/canonical-kubernetes-435
 ```
 
+<div class="p-notification--positive">
+  <p markdown="1" class="p-notification__response">
+    <span class="p-notification__status">Older Versions:</span>
+Previous versions of <strong>CDK</strong> used the name
+<code>canonical-kubernetes</code>. These versions are still available under that name
+and links in the charm store. Versions from 1.14 onwards will use
+<code>charmed-kubernetes</code>.
+  </p>
+</div>
+
+
 The revision numbers for bundles are generated automatically when the bundle is
 updated, including for testing and beta versions, so it isn't always the case
 that a higher revision number is 'better'. The revision numbers for the release
@@ -124,7 +135,11 @@ versions of the **CDK** bundle are shown in the table below:
 
 | Kubernetes version | CDK bundle |
 | --- | --- |
+<<<<<<< HEAD
+| 1.14.x         | [charmed-kubernetes-3](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-3/archive/bundle.yaml?channel=stable) |
+=======
 | 1.14.x         | [canonical-kubernetes-471](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-471/archive/bundle.yaml?channel=stable) |
+>>>>>>> 08f2fb860d29e5b46c35fd706f995a65019f0a49
 | 1.13.x         | [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-435/archive/bundle.yaml?channel=stable) |
 | 1.12.x         | [canonical-kubernetes-357](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-357/archive/bundle.yaml?channel=stable) |
 | 1.11.x         | [canonical-kubernetes-254](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-254/archive/bundle.yaml?channel=stable) |
@@ -272,7 +287,7 @@ specifying the charm to use, and further specifies the relationships to add.
 To use this overlay with the **CDK** bundle, it is specified during deploy like this:
 
 ```bash
-juju deploy canonical-kubernetes  --overlay ~/path/aws-overlay.yaml
+juju deploy charmed-kubernetes  --overlay ~/path/aws-overlay.yaml
 ```
 
 Substitute in the local path and filename to point to your YAML fragment.
@@ -408,7 +423,7 @@ For more information on the Juju GUI, see the [Juju documentation][juju-gui].
 [juju-gui]: https://docs.jujucharms.com/stable/en/controllers-gui
 [juju-constraints]: https://docs.jujucharms.com/stable/en/reference-constraints
 [asset-aws-overlay]: https://raw.githubusercontent.com/juju-solutions/kubernetes-docs/master/assets/aws-overlay.yaml
-[latest-bundle-file]: https://api.jujucharms.com/charmstore/v5/~containers/canonical-kubernetes/archive/bundle.yaml
+[latest-bundle-file]: https://api.jujucharms.com/charmstore/v5/charmed-kubernetes/archive/bundle.yaml?channel=stable
 [charm-kworker]: https://jujucharms.com/u/containers/kubernetes-worker/#configuration
 [snaps]: https://docs.snapcraft.io/snap-documentation
 [kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/

--- a/templates/kubernetes/docs/operations.md
+++ b/templates/kubernetes/docs/operations.md
@@ -281,11 +281,9 @@ things you may wish to try:
 ## Additional Resources
 
 - [Kubernetes User Guide](https://kubernetes.io/docs/user-guide/)
-- [The Canonical Distribution of Kubernetes](https://jujucharms.com/canonical-kubernetes/bundle/)
-- [Canonical Kubernetes Demos](https://github.com/CanonicalLtd/canonical-kubernetes-demos)
-- [Canonical Kubernetes Third-party Integrations](https://github.com/CanonicalLtd/canonical-kubernetes-third-party-integrations)
-- [Bundle Source](https://github.com/juju-solutions/bundle-kubernetes-core)
-- [Bug tracker](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues)
+- [The Charmed Distribution of Kubernetes](https://jujucharms.com/charmed-kubernetes/)
+- [Bundle source][bundle-source]
+- [Bug tracker](https://bugs.launchpad.net/charmed-kubernetes)
 
 
 <!--LINKS-->
@@ -296,3 +294,4 @@ things you may wish to try:
 [logging]: /kubernetes/docs/logging
 [decommission]: /kubernetes/docs/decommissioning
 [get-in-touch]:  /kubernetes/docs/get-in-touch
+[bundle-source]: https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-3/archive/bundle.yaml?channel=stable

--- a/templates/kubernetes/docs/using-vault.md
+++ b/templates/kubernetes/docs/using-vault.md
@@ -60,7 +60,7 @@ relations:
 Save this to a file named `k8s-vault.yaml` and deploy with:
 
 ```bash
-juju deploy cs:canonical-kubernetes --overlay ./k8s-vault.yaml
+juju deploy charmed-kubernetes --overlay ./k8s-vault.yaml
 ```
 
 Once the deployment settles, you will notice that several applications are in a
@@ -131,4 +131,4 @@ More details can be found [in the guide][vault-guide-ha].
 [vault-guide-ha]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-vault.html#enabling-ha
 [csr]: https://en.wikipedia.org/wiki/Certificate_signing_request
 [leadership]: https://docs.jujucharms.com/stable/en/authors-charm-leadership
-[cdk-bundle]: https://jujucharms.com/canonical-kubernetes
+[cdk-bundle]: https://jujucharms.com/charmed-kubernetes


### PR DESCRIPTION
## Done

The CDK charms are now published as `charmed-kubernetes` in the charm store. This updates the docs to deploy from that bundle rather than canonical-kubernetes.


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)

