### PR TITLE
Add raspberry pi 2 or 3 core page to nav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -344,6 +344,9 @@ download:
         - title: Raspberry Pi 2 or 3
           path: /download/iot/raspberry-pi-2-3
           hidden: True
+        - title: Raspberry Pi 2 or 3 Core
+          path: /download/iot/raspberry-pi-2-3-core
+          hidden: True
         - title: Raspberry Pi Compute Module 3
           path: /download/iot/raspberry-pi-compute-module-3
           hidden: True


### PR DESCRIPTION
## Done

- add the core install page for the pi to the nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/iot/raspberry-pi-2-3-core](http://0.0.0.0:8001/download/iot/raspberry-pi-2-3-core)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the page has a secondary nav

## Screenshots

![image](https://user-images.githubusercontent.com/441217/56369129-a2a0c000-61f0-11e9-8b53-7efcdb74daa6.png)
