### PR TITLE
Add esm to 20.04 and fix whitespace date bug

### DIFF
--- a/static/js/chartData.js
+++ b/static/js/chartData.js
@@ -25,7 +25,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date('2017-04-01T00:00:00'),
-    endDate: new Date('  2019-04-01T00:00:00'),
+    endDate: new Date('2019-04-01T00:00:00'),
     taskName: 'Ubuntu 12.04 LTS',
     status: 'EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS'
   },
@@ -43,7 +43,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date('2019-04-01T00:00:00'),
-    endDate: new Date('  2022-04-01T00:00:00'),
+    endDate: new Date('2022-04-01T00:00:00'),
     taskName: 'Ubuntu 14.04 LTS',
     status: 'EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS'
   },
@@ -61,15 +61,9 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date('2021-04-01T00:00:00'),
-    endDate: new Date('  2024-04-01T00:00:00'),
+    endDate: new Date('2024-04-01T00:00:00'),
     taskName: 'Ubuntu 16.04 LTS',
     status: 'EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS'
-  },
-  {
-    startDate: new Date('2017-10-01T00:00:00'),
-    endDate: new Date('2018-07-01T00:00:00'),
-    taskName: 'Ubuntu 17.10',
-    status: 'INTERIM_RELEASE'
   },
   {
     startDate: new Date('2018-04-01T00:00:00'),
@@ -86,7 +80,7 @@ export var serverAndDesktopReleases = [
 
   {
     startDate: new Date('2023-04-01T00:00:00'),
-    endDate: new Date('  2028-04-01T00:00:00'),
+    endDate: new Date('2028-04-01T00:00:00'),
     taskName: 'Ubuntu 18.04 LTS',
     status: 'EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS'
   },
@@ -119,6 +113,12 @@ export var serverAndDesktopReleases = [
     endDate: new Date('2025-04-01T00:00:00'),
     taskName: 'Ubuntu 20.04 LTS',
     status: 'MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2025-04-02T00:00:00'),
+    endDate: new Date('2030-04-02T00:00:00'),
+    taskName: 'Ubuntu 20.04 LTS',
+    status: 'EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS'
   },
   {
     startDate: new Date('2020-10-01T00:00:00'),
@@ -329,7 +329,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date('2025-04-01T00:00:00'),
-    endDate: new Date(''),
+    endDate: new Date('2030-04-01T00:00:00'),
     taskName: 'Ubuntu 20.04 LTS',
     status: 'EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS'
   },
@@ -574,7 +574,6 @@ export var desktopServerReleaseNames = [
   'Ubuntu 19.04',
   'Ubuntu 18.10',
   'Ubuntu 18.04 LTS',
-  'Ubuntu 17.10',
   'Ubuntu 16.04 LTS',
   'Ubuntu 14.04 LTS',
   'Ubuntu 12.04 LTS',

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -51,97 +51,79 @@
             <td><strong>Ubuntu 22.04 LTS</strong></td>
             <td>April 2022</td>
             <td>April 2027</td>
-            <td>&nbsp;</td>
+            <td></td>
           </tr>
           <tr>
             <td>Ubuntu 21.10</td>
             <td>October 2021</td>
             <td>July 2022</td>
-            <td>&nbsp;</td>
+            <td></td>
           </tr>
           <tr>
             <td>Ubuntu 21.04</td>
             <td>April 2021</td>
             <td>January 2022</td>
-            <td>&nbsp;</td>
+            <td></td>
           </tr>
           <tr>
             <td>Ubuntu 20.10</td>
             <td>October 2020</td>
             <td>July 2021</td>
-            <td>&nbsp;</td>
+            <td></td>
           </tr>
           <tr>
             <td><strong>Ubuntu 20.04 LTS</strong></td>
             <td>April 2020</td>
             <td>April 2025</td>
-            <td>&nbsp;</td>
+            <td>April 2030</td>
           </tr>
           <tr>
             <td>Ubuntu 19.10</td>
             <td>October 2019</td>
             <td>July 2020</td>
-            <td>&nbsp;</td>
+            <td></td>
           </tr>
           <tr>
             <td>Ubuntu 19.04</td>
             <td>April 2019</td>
             <td>January 2020</td>
-            <td>&nbsp;</td>
+            <td></td>
           </tr>
           <tr>
             <td>Ubuntu 18.10</td>
             <td>October 2018</td>
             <td>July 2019</td>
-            <td>&nbsp;</td>
+            <td></td>
           </tr>
           <tr>
             <td><strong>Ubuntu 18.04 LTS</strong></td>
             <td>April 2018</td>
             <td>April 2023</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 17.10</td>
-            <td>October 2017</td>
-            <td>July 2018</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 17.04</td>
-            <td>April 2017</td>
-            <td>January 2018</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 16.10</td>
-            <td>October 2016</td>
-            <td>June 2017</td>
-            <td>&nbsp;</td>
+            <td>April 2028</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 16.04 LTS</strong></td>
             <td>April 2016</td>
             <td>April 2021</td>
-            <td>&nbsp;</td>
+            <td>April 2024</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 14.04 LTS</strong></td>
             <td>April 2014</td>
             <td>April 2019</td>
-            <td>&nbsp;</td>
+            <td>April 2022</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 12.04 LTS</strong></td>
             <td>April 2012</td>
             <td>April 2017</td>
-            <td>April 2020</td>
+            <td>April 2019</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 10.04 LTS</strong></td>
             <td>April 2010</td>
             <td>April 2015</td>
-            <td>&nbsp;</td>
+            <td></td>
           </tr>
         </tbody>
       </table>
@@ -276,7 +258,7 @@
             <td><strong>Ubuntu 20.04 LTS</strong></td>
             <td>April 2020</td>
             <td>April 2025</td>
-            <td>&nbsp;</td>
+            <td>April 2030</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 18.04.4 LTS</strong></td>


### PR DESCRIPTION
## Done

- removed spaces in dates for desktop/server
- added esm for 20.04 lts

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/about/release-cycle](http://0.0.0.0:8001/about/release-cycle)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- see that esm appears in the 'Long term support and interim releases' chart and that esm is on the 20.04 bar for 'Ubuntu kernel release cycle'

## Issue / Card

Fixes #4985

