### PR TITLE
Create new openstack security takeover page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -32,11 +32,12 @@
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
+  {% include "takeovers/_openstack_takeover-new.html"%}
   {% include "takeovers/_1904-takeover.html" %}
   {% include "takeovers/_ci-cd-webinar.html" %}
   {% include "takeovers/_14-04-esm.html" %}
   {% include "takeovers/_snap-deltas-takeover.html" %}
-{% endblock takeover_content %}
+  {% endblock takeover_content %}
 
 
 {#

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,11 +32,7 @@
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
-<<<<<<< HEAD
-  {% include "takeovers/_openstack_takeover-new.html"%}
-=======
   {% include "takeovers/_openstack_security_takeover.html" %}
->>>>>>> Update button & link click event labels and actions
   {% include "takeovers/_1904-takeover.html" %}
   {% include "takeovers/_ci-cd-webinar.html" %}
   {% include "takeovers/_14-04-esm.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,11 @@
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
+<<<<<<< HEAD
   {% include "takeovers/_openstack_takeover-new.html"%}
+=======
+  {% include "takeovers/_openstack_security_takeover.html" %}
+>>>>>>> Update button & link click event labels and actions
   {% include "takeovers/_1904-takeover.html" %}
   {% include "takeovers/_ci-cd-webinar.html" %}
   {% include "takeovers/_14-04-esm.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,7 +37,7 @@
   {% include "takeovers/_ci-cd-webinar.html" %}
   {% include "takeovers/_14-04-esm.html" %}
   {% include "takeovers/_snap-deltas-takeover.html" %}
-  {% endblock takeover_content %}
+{% endblock takeover_content %}
 
 
 {#

--- a/templates/takeovers/_openstack_security_takeover.html
+++ b/templates/takeovers/_openstack_security_takeover.html
@@ -1,58 +1,52 @@
 <section class="p-strip--dark p-takeover js-takeover">
-  <div class="row">
-    <div class="p-takeover__body u-clearfix u-vertically-center">
-      <div class="col-8">
-        <h1 class="p-takeover__title">Private cloud security</h1>
-        <p class="p-heading--four u-no-margin--right">
-          Meeting the highest enterprise requirements with OpenStack.
-        </p>
-        <ul class="p-inline-list u-hide--small">
-          <li class="p-inline-list__item">
-            <!-- Update link -->
-            <a
-              href="/engage/openstack-security-webinar?utm_source=Takeover &utm_medium=Takeover&utm_campaign=CY19_DC_Openstack_WBN_OpenStackSecurity"
-              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'OpenStack Security WP & Webinar takeover', 'eventLabel' : 'Register for the webinar', 'eventValue' : undefined });"
-              class="p-button--positive"
-              ><span>Register for the webinar</span></a
-            >
-          </li>
-          <li class="p-inline-list__item">
-            <!-- Update link -->
-            <a
-              href="/engage/19-04-webinar?utm_source=takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
-              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'OpenStack Security WP & Webinar takeover', 'eventLabel' : 'Download the whitepaper', 'eventValue' : undefined });"
-              class="p-link--inverted"
-              >Download the whitepaper&nbsp;›</a
-            >
-          </li>
-        </ul>
-      </div>
-      <div class="col-4">
-        <p class="p-takeover__image u-align-text--center">
-          <img
-            src="{{ ASSET_SERVER_URL }}2c91289c-openstack-cloud.svg"
-            alt=""
-          />
-        </p>
-        <p class="u-hide--medium u-hide--large">
-          <!-- Update link -->
+  <div class="row u-clearfix u-vertically-center">
+    <div class="col-8">
+      <h1>Private cloud security</h1>
+      <p class="p-heading--four u-sv2">
+        Meeting the highest enterprise requirements with OpenStack.
+      </p>
+      <ul class="p-inline-list u-hide--small">
+        <li class="p-inline-list__item">
           <a
-            href="/engage/openstack-security-webinar?utm_source=Takeover &utm_medium=Takeover&utm_campaign=CY19_DC_Openstack_WBN_OpenStackSecurity"
+            href="/engage/openstack-security-webinar"
             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'OpenStack Security WP & Webinar takeover', 'eventLabel' : 'Register for the webinar', 'eventValue' : undefined });"
             class="p-button--positive"
             ><span>Register for the webinar</span></a
           >
-        </p>
-        <p class="u-hide--medium u-hide--large">
-          <!-- Update link -->
+        </li>
+        <li class="p-inline-list__item">
           <a
-            href="/engage/19-04-webinar?utm_source=takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
+            href="/engage/openstack-security-whitepaper"
             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'OpenStack Security WP & Webinar takeover', 'eventLabel' : 'Download the whitepaper', 'eventValue' : undefined });"
             class="p-link--inverted"
             >Download the whitepaper&nbsp;›</a
           >
-        </p>
-      </div>
+        </li>
+      </ul>
+    </div>
+    <div class="col-4">
+      <p class="p-takeover__image u-align-text--center">
+        <img
+          src="{{ ASSET_SERVER_URL }}2c91289c-openstack-cloud.svg"
+          alt=""
+        />
+      </p>
+      <p class="u-hide--medium u-hide--large">
+        <a
+          href="/engage/openstack-security-webinar"
+          onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'OpenStack Security WP & Webinar takeover', 'eventLabel' : 'Register for the webinar', 'eventValue' : undefined });"
+          class="p-button--positive"
+          ><span>Register for the webinar</span></a
+        >
+      </p>
+      <p class="u-hide--medium u-hide--large">
+        <a
+          href="/engage/openstack-security-whitepaper"
+          onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'OpenStack Security WP & Webinar takeover', 'eventLabel' : 'Download the whitepaper', 'eventValue' : undefined });"
+          class="p-link--inverted"
+          >Download the whitepaper&nbsp;›</a
+        >
+      </p>
     </div>
   </div>
   <style>

--- a/templates/takeovers/_openstack_security_takeover.html
+++ b/templates/takeovers/_openstack_security_takeover.html
@@ -68,6 +68,9 @@
       width: 313px
     }
     @media (max-width: 874px) {
+      .p-takeover {
+        background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+      }
       .p-takeover__image {
         width: 261px;
       }

--- a/templates/takeovers/_openstack_security_takeover.html
+++ b/templates/takeovers/_openstack_security_takeover.html
@@ -8,16 +8,14 @@
       <ul class="p-inline-list u-hide--small">
         <li class="p-inline-list__item">
           <a
-            href="/engage/openstack-security-webinar"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'OpenStack Security WP & Webinar takeover', 'eventLabel' : 'Register for the webinar', 'eventValue' : undefined });"
+            href="/engage/openstack-security-webinar?utm_source=takeover&utm_campaign=CY19_DC_Openstack_WBN_OpenStackSecurity"
             class="p-button--positive"
             ><span>Register for the webinar</span></a
           >
         </li>
         <li class="p-inline-list__item">
           <a
-            href="/engage/openstack-security-whitepaper"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'OpenStack Security WP & Webinar takeover', 'eventLabel' : 'Download the whitepaper', 'eventValue' : undefined });"
+            href="/engage/openstack-security-whitepaper?utm_source=takeover&utm_campaign=CY19_DC_Openstack_Whitepaper_Security"
             class="p-link--inverted"
             >Download the whitepaper&nbsp;›</a
           >
@@ -33,16 +31,14 @@
       </p>
       <p class="u-hide--medium u-hide--large">
         <a
-          href="/engage/openstack-security-webinar"
-          onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'OpenStack Security WP & Webinar takeover', 'eventLabel' : 'Register for the webinar', 'eventValue' : undefined });"
+          href="/engage/openstack-security-webinar?utm_source=takeover&utm_campaign=CY19_DC_Openstack_WBN_OpenStackSecurity"
           class="p-button--positive"
           ><span>Register for the webinar</span></a
         >
       </p>
       <p class="u-hide--medium u-hide--large">
         <a
-          href="/engage/openstack-security-whitepaper"
-          onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'OpenStack Security WP & Webinar takeover', 'eventLabel' : 'Download the whitepaper', 'eventValue' : undefined });"
+          href="/engage/openstack-security-whitepaper?utm_source=takeover&utm_campaign=CY19_DC_Openstack_Whitepaper_Security"
           class="p-link--inverted"
           >Download the whitepaper&nbsp;›</a
         >

--- a/templates/takeovers/_openstack_security_takeover.html
+++ b/templates/takeovers/_openstack_security_takeover.html
@@ -1,0 +1,76 @@
+<section class="p-strip--dark p-takeover js-takeover">
+  <div class="row">
+    <div class="p-takeover__body u-clearfix u-vertically-center">
+      <div class="col-8">
+        <h1 class="p-takeover__title">Private cloud security</h1>
+        <p class="p-heading--four u-no-margin--right">
+          Meeting the highest enterprise requirements with OpenStack.
+        </p>
+        <ul class="p-inline-list u-hide--small">
+          <li class="p-inline-list__item">
+            <!-- Update link -->
+            <a
+              href="/engage/openstack-security-webinar?utm_source=Takeover &utm_medium=Takeover&utm_campaign=CY19_DC_Openstack_WBN_OpenStackSecurity"
+              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'OpenStack Security WP & Webinar takeover', 'eventLabel' : 'Register for the webinar', 'eventValue' : undefined });"
+              class="p-button--positive"
+              ><span>Register for the webinar</span></a
+            >
+          </li>
+          <li class="p-inline-list__item">
+            <!-- Update link -->
+            <a
+              href="/engage/19-04-webinar?utm_source=takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
+              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'OpenStack Security WP & Webinar takeover', 'eventLabel' : 'Download the whitepaper', 'eventValue' : undefined });"
+              class="p-link--inverted"
+              >Download the whitepaper&nbsp;›</a
+            >
+          </li>
+        </ul>
+      </div>
+      <div class="col-4">
+        <p class="p-takeover__image u-align-text--center">
+          <img
+            src="{{ ASSET_SERVER_URL }}2c91289c-openstack-cloud.svg"
+            alt=""
+          />
+        </p>
+        <p class="u-hide--medium u-hide--large">
+          <!-- Update link -->
+          <a
+            href="/engage/openstack-security-webinar?utm_source=Takeover &utm_medium=Takeover&utm_campaign=CY19_DC_Openstack_WBN_OpenStackSecurity"
+            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'OpenStack Security WP & Webinar takeover', 'eventLabel' : 'Register for the webinar', 'eventValue' : undefined });"
+            class="p-button--positive"
+            ><span>Register for the webinar</span></a
+          >
+        </p>
+        <p class="u-hide--medium u-hide--large">
+          <!-- Update link -->
+          <a
+            href="/engage/19-04-webinar?utm_source=takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
+            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'OpenStack Security WP & Webinar takeover', 'eventLabel' : 'Download the whitepaper', 'eventValue' : undefined });"
+            class="p-link--inverted"
+            >Download the whitepaper&nbsp;›</a
+          >
+        </p>
+      </div>
+    </div>
+  </div>
+  <style>
+    .p-takeover {
+      background-image: url("{{ ASSET_SERVER_URL }}e6a2c401-suru-left.svg"),
+        url("{{ ASSET_SERVER_URL }}a9dab044-suru-right.svg"),
+        linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+      background-position: left, right;
+      background-repeat: no-repeat, no-repeat;
+      background-size: auto 100%, auto 100%, cover;
+    }
+    .p-takeover__image {
+      width: 313px
+    }
+    @media (max-width: 874px) {
+      .p-takeover__image {
+        width: 261px;
+      }
+    }
+  </style>
+</section>

--- a/templates/takeovers/_openstack_takeover.html
+++ b/templates/takeovers/_openstack_takeover.html
@@ -1,4 +1,4 @@
-<div class="box box-highlight box-hero no-border">
+<div class="box box-highlight box-hero no-border p-takeover js-takeover">
 	<div class="hero clearfix">
 		<div itemscope itemtype="https://schema.org/Product">
 			<h1 itemprop="name">Ubuntu is the <br />OpenStack favourite</h1>


### PR DESCRIPTION
## Done

Create a new 'OpenStack Security' takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Open [http://0.0.0.0:8001/](http://0.0.0.0:8001/) and refresh the page until the OpenStack takeover comes up
- Make sure [design](https://github.com/canonical-web-and-design/www.ubuntu.com/issues/4938) is ok
- Make sure is compliant with the [brief](https://docs.google.com/document/d/1Qg3sgDrvH9w_sgJpb2fp5lyOA5R-xhGZM3aKcyuQT68/edit#)


## Issue / Card

Fixes [#4940](https://github.com/canonical-web-and-design/www.ubuntu.com/issues/4940) 

