### PR TITLE
Add openstack security webinar landing page

### DIFF
--- a/templates/engage/openstack-security-webinar.html
+++ b/templates/engage/openstack-security-webinar.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="Private cloud security" subtitle="How Charmed OpenStack is decreasing common security concerns" class="p-strip--dark p-takeover--openstack"%}
+{% include "engage/shared/_header.html" with title="Private cloud security" subtitle="How Charmed OpenStack is decreasing common security concerns" class="p-strip--dark p-takeover--openstack" url="#register-section" cta="Watch the webinar" %}
 
 <section class="p-strip is-shallow is-bordered">
   <div class="row">
@@ -30,7 +30,7 @@
           Examine how automation can help address these concerns
         </li>
         <li class="p-list__item is-ticked">
-          Explore how Charmes Openstack can help deploy key security features:
+          Explore how Charmed Openstack can help deploy key security features:
           <ul>
             <li>
               Offer encryption at rest as a service to private cloud users
@@ -41,7 +41,6 @@
           </ul>
         </li>
       </ul>
-      <p><a href="https://ubuntu.com/engage/openstack-security-webinar?utm_source=Takeover &utm_medium=Takeover&utm_campaign=CY19_DC_Openstack_WBN_OpenStackSecurity" class="p-button--positive">Register for webinar</a></p>
     </div>
   </div>
   <style>
@@ -49,6 +48,14 @@
       background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
     }
   </style>
+</section>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 id="register-section">Watch the webinar</h2>
+    </div>
+    <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 355328, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+  </div>
 </section>
 
 {% endblock content %}

--- a/templates/engage/openstack-security-webinar.html
+++ b/templates/engage/openstack-security-webinar.html
@@ -13,8 +13,7 @@
     <div class="col-7">
       <h1>How Charmed OpenStack is decreasing common security concerns</h1>
       <p>
-        <!-- Add webinar registration link -->
-        <a href="" class="p-button--positive">
+        <a href="https://www.ubuntu.com/engage/openstack-security-webinar?utm_source=Takeover%2520&utm_medium=Takeover&utm_campaign=CY19_DC_Openstack_WBN_OpenStackSecurity" class="p-button--positive">
           Register for the webinar
         </a>
       </p>

--- a/templates/engage/openstack-security-webinar.html
+++ b/templates/engage/openstack-security-webinar.html
@@ -1,50 +1,59 @@
 {% extends "engage/base_engage.html" %}
 
+{% block title %}Private cloud security{% endblock %}
+
 {% block meta_description %}In regulated sectors, private cloud security needs to meet the highest requirements. This webinar explains how to deliver on these with an Openstack cloud.{% endblock %}
 
-{% block title %}Private cloud security{% endblock %}
-<!-- Edit this link -->
-{% block meta_copydoc %}https://docs.google.com/document/d/1zAv3ouUrzQcQDw2DSefaePXcMu35BAumIMpzqmIkycs/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Qg3sgDrvH9w_sgJpb2fp5lyOA5R-xhGZM3aKcyuQT68/edit?ts=5cbee163#{% endblock meta_copydoc %}
 
 {% block content %}
 
-<section class="p-strip--image is-deep js-takeover is-dark p-takeover">
-  <div class="row u-vertically-center">
-    <div class="col-7">
-      <h1>How Charmed OpenStack is decreasing common security concerns</h1>
-      <p>
-        <a href="https://www.ubuntu.com/engage/openstack-security-webinar?utm_source=Takeover%2520&utm_medium=Takeover&utm_campaign=CY19_DC_Openstack_WBN_OpenStackSecurity" class="p-button--positive">
-          Register for the webinar
-        </a>
-      </p>
-    </div>
-  <style>
-    .p-takeover {
-      background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
-    }
-    .p-takeover__image {
-      width: 313px
-    }
-  </style>
-</section>
+{% include "engage/shared/_header.html" with title="Private cloud security" subtitle="How Charmed OpenStack is decreasing common security concerns" class="p-strip--dark p-takeover--openstack"%}
 
 <section class="p-strip is-shallow is-bordered">
   <div class="row">
     <div class="col-8">
-      <p>Telco, finance, insurance, healthcare, governments are among the regulated sectors, where security and in particular data privacy are fundamental to the design of a private cloud. Openstack is a popular solution to deploy secure private clouds. Implementing Openstack in regulated environments and matching stringent security requirement however can be operationally challenging and costly.</p>
-      <p>Watch this webinar to:</p>
-      <ul>
-        <li>Understand common practices to operate secure private clouds based on Openstack</li>
-        <li>Understand operational concerns associated with these practices</li>
-        <li>Examine how automation can help address these concerns</li>
-        <li>Explore how Charmes Openstack can help deploy key security features:</li>
-        <ul>
-          <li>Offer encryption at rest as a service to private cloud users</li>
-          <li>Implement certificate lifecycle management to keep data secure in all scenarios</li>
-        </ul>
+      <p>
+        Telco, finance, insurance, healthcare, governments are among the regulated sectors, where security and in particular data privacy are fundamental to the design of a private cloud. Openstack is a popular solution to deploy secure private clouds. Implementing Openstack in regulated environments and matching stringent security requirement however can be operationally challenging and costly. 
+      </p>
+      <h4>
+        Watch this webinar to:
+      </h4>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">
+          Understand common practices to operate secure private clouds based on Openstack
+        </li>
+        <li class="p-list__item is-ticked">
+          Understand operational concerns associated with these practices 
+        </li>
+        <li class="p-list__item is-ticked">
+          Examine how automation can help address these concerns
+        </li>
+        <li class="p-list__item is-ticked">
+          Explore how Charmes Openstack can help deploy key security features:
+          <ul class="p-list--nested">
+            <li class="p-list__item is-ticked">
+              Offer encryption at rest as a service to private cloud users
+            </li>
+            <li class="p-list__item is-ticked">
+              Implement certificate lifecycle management to keep data secure in all scenarios
+            </li>
+          </ul>
+        </li>
       </ul>
+      <p><a href="https://ubuntu.com/engage/openstack-security-webinar?utm_source=Takeover &utm_medium=Takeover&utm_campaign=CY19_DC_Openstack_WBN_OpenStackSecurity" class="p-button--positive">Register for webinar</a></p>
     </div>
   </div>
+  <style>
+    .p-list--nested {
+      list-style: none;
+      margin-left: 0;
+      padding-left: 0;
+    }
+    .p-takeover--openstack {
+      background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+    }
+  </style>
 </section>
 
 {% endblock content %}

--- a/templates/engage/openstack-security-webinar.html
+++ b/templates/engage/openstack-security-webinar.html
@@ -31,11 +31,11 @@
         </li>
         <li class="p-list__item is-ticked">
           Explore how Charmes Openstack can help deploy key security features:
-          <ul class="p-list--nested">
-            <li class="p-list__item is-ticked">
+          <ul>
+            <li>
               Offer encryption at rest as a service to private cloud users
             </li>
-            <li class="p-list__item is-ticked">
+            <li>
               Implement certificate lifecycle management to keep data secure in all scenarios
             </li>
           </ul>
@@ -45,11 +45,6 @@
     </div>
   </div>
   <style>
-    .p-list--nested {
-      list-style: none;
-      margin-left: 0;
-      padding-left: 0;
-    }
     .p-takeover--openstack {
       background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
     }

--- a/templates/engage/openstack-security-webinar.html
+++ b/templates/engage/openstack-security-webinar.html
@@ -1,0 +1,51 @@
+{% extends "engage/base_engage.html" %}
+
+{% block meta_description %}In regulated sectors, private cloud security needs to meet the highest requirements. This webinar explains how to deliver on these with an Openstack cloud.{% endblock %}
+
+{% block title %}Private cloud security{% endblock %}
+<!-- Edit this link -->
+{% block meta_copydoc %}https://docs.google.com/document/d/1zAv3ouUrzQcQDw2DSefaePXcMu35BAumIMpzqmIkycs/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--image is-deep js-takeover is-dark p-takeover">
+  <div class="row u-vertically-center">
+    <div class="col-7">
+      <h1>How Charmed OpenStack is decreasing common security concerns</h1>
+      <p>
+        <!-- Add webinar registration link -->
+        <a href="" class="p-button--positive">
+          Register for the webinar
+        </a>
+      </p>
+    </div>
+  <style>
+    .p-takeover {
+      background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+    }
+    .p-takeover__image {
+      width: 313px
+    }
+  </style>
+</section>
+
+<section class="p-strip is-shallow is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <p>Telco, finance, insurance, healthcare, governments are among the regulated sectors, where security and in particular data privacy are fundamental to the design of a private cloud. Openstack is a popular solution to deploy secure private clouds. Implementing Openstack in regulated environments and matching stringent security requirement however can be operationally challenging and costly.</p>
+      <p>Watch this webinar to:</p>
+      <ul>
+        <li>Understand common practices to operate secure private clouds based on Openstack</li>
+        <li>Understand operational concerns associated with these practices</li>
+        <li>Examine how automation can help address these concerns</li>
+        <li>Explore how Charmes Openstack can help deploy key security features:</li>
+        <ul>
+          <li>Offer encryption at rest as a service to private cloud users</li>
+          <li>Implement certificate lifecycle management to keep data secure in all scenarios</li>
+        </ul>
+      </ul>
+    </div>
+  </div>
+</section>
+
+{% endblock content %}


### PR DESCRIPTION
## Done

Add openstack security webinar landing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/engage/openstack-security-webinar](http://0.0.0.0:8001/engage/openstack-security-webinar)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Make sure it matches the [brief](https://docs.google.com/document/d/1Qg3sgDrvH9w_sgJpb2fp5lyOA5R-xhGZM3aKcyuQT68/edit?ts=5cbee163#heading=h.1v2sl7iz5yrb)


## Issue / Card

Fixes [#1100](https://github.com/canonical-web-and-design/web-squad/issues/1100)

