### PR TITLE
Remove old takeovers from rotation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,6 @@
   {# GERMAN #}
   {% include "takeovers/_german_ai_webinar.html" %}
   {% include "takeovers/_german-compliance-webinar.html" %}
-  {% include "takeovers/_german_takeover_k8.html" %}
   {# FRENCH #}
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,7 +37,6 @@
   {% include "takeovers/_ci-cd-webinar.html" %}
   {% include "takeovers/_14-04-esm.html" %}
   {% include "takeovers/_snap-deltas-takeover.html" %}
-  {% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
 {% endblock takeover_content %}
 
 
@@ -62,4 +61,3 @@
 {% block notices_content %}
   {% include "shared/_notice_default.html" with lang="ja" text="私たちの日本のウェブサイトを試してみてください" url="https://jp.ubuntu.com" icon="https://assets.ubuntu.com/v1/8114528b-picto-ubuntu-orange.png" %}
 {% endblock notices_content %}
-


### PR DESCRIPTION
## Done

- Removed the 451 financial services whitepaper takeover from rotation
- Removed the german k8s webinar takeover from rotation
- Updated the [master content tracker](https://docs.google.com/spreadsheets/d/1MaFd-ZHWpRVjIP9Sj_dOCIGOtl-GJYbrXewt5EG4m80/edit?ts=5cc05f70#gid=564832475)
- Left the files on the site for now

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Reload the page until your are satisfied you do not see the takeovers

## Issue / Card

Fixes #4991

## Screenshot

### removed takeovers

![image](https://user-images.githubusercontent.com/441217/56683220-016caa80-66c5-11e9-9cc9-a92a9448d1eb.png)

![image](https://user-images.githubusercontent.com/441217/56686462-f10bfe00-66cb-11e9-9e53-f37fef9ad2cf.png)
