### PR TITLE
Update blog link on /openstack/storage page

### DIFF
--- a/templates/openstack/storage.html
+++ b/templates/openstack/storage.html
@@ -33,7 +33,6 @@
         <p>Public clouds have pioneered the approach of network-hosted software-defined storage architectures, delivering very reliable and efficient storage at low cost. Traditional enterprise SAN (Storage Area Network) and NAS (Network Attached Storage) solutions are now considered expensive to purchase, expand and upgrade.</p>
         <p>The data center is following, and software-defined storage based on commodity servers and disks with Ubuntu has become the new norm for high-growth low-cost block storage, object stores and data lakes. Open source Ceph, Swift and HDFS enable massive enterprise operations with total costs in line with the underlying bulk commodity disk prices.</p>
         <p>Ubuntu Advantage Storage is the proven enterprise software-defined storage offering at the lowest per gigabyte price.</p>
-        <p><a class="p-link--external" href="https://blog.ubuntu.com/2015/05/18/ubuntu-advantage-storage-factsheet">Read the Ubuntu Advantage Storage factsheet</a></p>
       </div>
 
       <div class="col-4">
@@ -42,7 +41,7 @@
             <p class="p-muted-heading">FAQ</p>
           </div>
           <div class="p-card__content u-no-margin--top">
-            <h3 class="p-card__title p-heading--four"><a href="https://blog.ubuntu.com/2015/05/18/ubuntu-advantage-storage-faqs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Ubuntu Storage FAQ', 'eventLabel' : 'from ubuntu.com/openstack/storage', 'eventValue' : undefined });">Ubuntu Advantage Storage FAQs&nbsp;&rsaquo;</a></h3>
+            <h3 class="p-card__title p-heading--four"><a href="https://blog.ubuntu.com/2015/05/18/ubuntu-advantage-storage-factsheet" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Ubuntu Storage FAQ', 'eventLabel' : 'from ubuntu.com/openstack/storage', 'eventValue' : undefined });">Ubuntu Advantage Storage FAQs&nbsp;&rsaquo;</a></h3>
             <p>Answers to your most frequently asked questions about Ubuntu Advantage Storage.</p>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Updated link in FAQ block
- Removed CTA that was to that same link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/openstack/storage](http://0.0.0.0:8001/openstack/storage)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that there is just the faq box and it links to a real page
- Note, the copy doc is based on the UA-I release

## Issue / Card

Fixes #4993

## Screenshots

![image](https://user-images.githubusercontent.com/441217/56687921-3e3d9f00-66cf-11e9-887d-1b73735b4f0e.png)
