### PR TITLE
Update community dropdown

### DIFF
--- a/templates/templates/_navigation-community-h.html
+++ b/templates/templates/_navigation-community-h.html
@@ -41,7 +41,7 @@
           <h4 class="p-muted-heading u-hide--medium u-hide--large">Meet</h4>
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item"><a href="https://askubuntu.com/">Ask Ubuntu &mdash; our StackExchange</a></li>
-            <li class="p-list__item"><a href="http://loco.ubuntu.com/events/">Join your Local Community team</a></li>
+            <li class="p-list__item"><a href="http://loco.ubuntu.com/teams/">Join your Local Community team</a></li>
             <li class="p-list__item"><a href="https://ubuntuforums.org/">Meet up in the Ubuntu Forums</a></li>
             <li class="p-list__item"><a href="https://help.ubuntu.com/community/InternetRelayChat">Chat on IRC</a></li>
           </ul>
@@ -52,7 +52,6 @@
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item"><a href="https://twitter.com/ubuntu">Ubuntu on Twitter</a></li>
             <li class="p-list__item"><a href="https://facebook.com/ubuntulinux">Facebook</a></li>
-            <li class="p-list__item"><a href="https://plus.google.com/+ubuntu">Google&plus;</a></li>
           </ul>
         </div>
         <div class="col-4">


### PR DESCRIPTION
## Done

- Fixed link to locos to use /teams
- Removed link to google+
- Updated the [copy doc](https://docs.google.com/document/d/1TgsBJdGgsP4KrGiz5kU5QYkdGSlKqhAVnZGnCJgshYY/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/#community](http://0.0.0.0:8001/#community)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the links to locos go to the teams
- See there is no Google+ link

## Issue / Card

Fixes #3927

