### PR TITLE
Fixed power netboot image links

### DIFF
--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -29,8 +29,8 @@
         <ul class="p-list">
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ latest_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ lts_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ previous_lts_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '16.04.2', 'eventValue' : undefined });">{{ previous_lts_release_with_point }} <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/14.04.6/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '14.04.6', 'eventValue' : undefined });">14.04.6&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/16.04/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '16.04', 'eventValue' : undefined });">16.04 <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/14.04/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '14.04', 'eventValue' : undefined });">14.04&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
     </div>

--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -29,7 +29,7 @@
         <ul class="p-list">
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ latest_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ lts_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/16.04/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '16.04', 'eventValue' : undefined });">16.04 <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ previous_lts_release }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ previous_lts_release }}', 'eventValue' : undefined });">{{ previous_lts_release_full }}&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/14.04/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '14.04', 'eventValue' : undefined });">14.04&nbsp;&rsaquo;</a></li>
         </ul>
       </div>

--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -21,7 +21,6 @@
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ latest_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ lts_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/{{ previous_lts_release_with_point }}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ previous_lts_release_with_point }}', 'eventValue' : undefined });">{{ previous_lts_release_with_point }} <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/releases/14.04.6/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '14.04.6', 'eventValue' : undefined });">14.04.6&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
       <div class="col-6">
@@ -30,32 +29,30 @@
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ latest_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ lts_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ previous_lts_release }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ previous_lts_release }}', 'eventValue' : undefined });">{{ previous_lts_release_full }}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/14.04/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '14.04', 'eventValue' : undefined });">14.04&nbsp;&rsaquo;</a></li>
         </ul>
+        <p>
+          <a class="p-link--external" href="http://cdimage.ubuntu.com/netboot/">Older versions of the netboot installer</a>
+        </p>
       </div>
     </div>
   </div>
 </div>
 
-<div class="p-strip is-bordered">
+<div class="p-strip--light is-bordered">
   <div class="row u-equal-height p-divider">
-    <div class="col-4 p-divider__block">
+    <div class="col-6 p-divider__block">
       <h3>Ubuntu {{ lts_release }} <abbr title="Long-term support">LTS</abbr> for IBM POWER</h3>
       <p>Ubuntu {{ lts_release }} LTS adds support for Openstack Queens, LXD 3.0 with clustering and resource quotas, netplan.io, Chrony, and fresh package updates throughout the distribution.  Ubuntu 18.04 is the first release to support Power9.</p>
       <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes">Ubuntu Server {{ lts_release }} <abbr title="Long-term support">LTS</abbr> release notes&nbsp;&rsaquo;</a></p>
     </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-6 p-divider__block">
       <h3>Ubuntu 16.04 <abbr title="Long-term support">LTS</abbr> for IBM POWER8</h3>
       <p>Ubuntu 16.04 continues to enable rapid innovation for POWER8 including support for new POWER8 models, memory and PCI Hotplug, Docker 1.9.1, many performance and availability enhancements. Includes the only commercially available Linux to provide initial support for support the OpenPOWER Foundation’s industry leading NVLink technology.</p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3>Ubuntu 14.04 for IBM POWER8</h3>
-      <p>Ubuntu 14.04 brings with it, for the first time, support for IBM POWER8 including our MAAS provisioning, Juju cloud orchestration, Landscape systems management and Ubuntu OpenStack.  Ubuntu 14.04.4 adds CAPI and PowerNV support.</p>
     </div>
   </div>
 </div>
 
-<div class="p-strip--light">
+<div class="p-strip">
   <div class="row">
     <div class="col-8">
       <h2>Ready to deploy now</h2>


### PR DESCRIPTION
## Done

- Removed point releases for 14.04 and 16.04 netbook links
- Updated the [copy doc](https://docs.google.com/document/d/1e-vav_b54KlKsi92w3rDu9J14O0gpp8yAanEAIImlE8/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/server/power](http://0.0.0.0:8001/download/server/power)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the 14.04 and 16.04 netbook links go to a page that has the generic series netbook link

## Issue / Card

Fixes #3746
