### PR TITLE
Update link to wiki in /download/flavours page

### DIFF
--- a/templates/download/flavours.html
+++ b/templates/download/flavours.html
@@ -79,7 +79,7 @@
         <li class="p-matrix__item u-hide--small">&nbsp;</li>
         <li class="p-matrix__item u-hide--small">&nbsp;</li>
       </ul>
-      <p>A complete list of known flavours, editions and customizations is maintained on the <a class="p-link--external" href="https://wiki.ubuntu.com/UbuntuFlavors">Ubuntu Wiki's UbuntuFlavors page</a>.</p>
+      <p>A complete list of known flavours, editions and customisations is maintained on the <a class="p-link--external" href="https://wiki.ubuntu.com/UbuntuFlavors">Ubuntu Wiki's UbuntuFlavors page</a>.</p>
     </div>
   </div>
 </div>

--- a/templates/download/flavours.html
+++ b/templates/download/flavours.html
@@ -79,7 +79,7 @@
         <li class="p-matrix__item u-hide--small">&nbsp;</li>
         <li class="p-matrix__item u-hide--small">&nbsp;</li>
       </ul>
-      <p>A complete list of known flavours, editions and customizations is maintained on the <a href="https://wiki.ubuntu.com/DerivativeTeam/Derivatives">Ubuntu Wiki Derivatives Team page</a>.</p>
+      <p>A complete list of known flavours, editions and customizations is maintained on the <a class="p-link--external" href="https://wiki.ubuntu.com/UbuntuFlavors">Ubuntu Wiki's UbuntuFlavors page</a>.</p>
     </div>
   </div>
 </div>

--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -29,8 +29,8 @@
         <ul class="p-list">
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ latest_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">{{ latest_release_with_point }}&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ lts_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ lts_release }}', 'eventValue' : undefined });">{{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/16.04/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '16.04', 'eventValue' : undefined });">16.04 <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/14.04/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '14.04', 'eventValue' : undefined });">14.04&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/{{ previous_lts_release_with_point }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '16.04.2', 'eventValue' : undefined });">{{ previous_lts_release_with_point }} <abbr title="Long-term support">LTS</abbr>&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="http://cdimage.ubuntu.com/netboot/14.04.6/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '14.04.6', 'eventValue' : undefined });">14.04.6&nbsp;&rsaquo;</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Updated link to dervitatives to flavors
- Updated the [copy doc](https://docs.google.com/document/d/1M5nkigcSRzq1YVjiXOZkeU4EUCqT0uYBR3Y_sjxM-wM/edit)
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/flavours](http://0.0.0.0:8001/download/flavours)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the link has been updated

## Issue / Card

Fixes #3226