### PR TITLE
Fix Kubernetes bundle refs

### DIFF
--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -135,7 +135,7 @@ versions of the **CDK** bundle are shown in the table below:
 
 | Kubernetes version | CDK bundle |
 | --- | --- |
-| 1.14.x         | [charmed-kubernetes-33](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-33/archive/bundle.yaml?channel=stable) |
+| 1.14.x         | [charmed-kubernetes-31](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-31/archive/bundle.yaml?channel=stable) |
 | 1.13.x         | [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-435/archive/bundle.yaml?channel=stable) |
 | 1.12.x         | [canonical-kubernetes-357](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-357/archive/bundle.yaml?channel=stable) |
 | 1.11.x         | [canonical-kubernetes-254](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-254/archive/bundle.yaml?channel=stable) |

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -16,7 +16,7 @@ toc: False
 
 # 1.14 Bugfix release
 
-### April 23rd, 2019 - [charmed-kubernetes-33](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-33/archive/bundle.yaml)
+### April 23rd, 2019 - [charmed-kubernetes-31](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-31/archive/bundle.yaml)
 
 ## Fixes
 


### PR DESCRIPTION
## Done

Some links updated to reference the correct version of the kubernetes bundle in
  install-manual.md
  release-notes.md

Merge if happy!

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
