### PR TITLE
Update raspberry pi strip on /download/iot

### DIFF
--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -10,22 +10,21 @@
     <h1>Get Ubuntu for IoT</h1>
   </div>
 </section>
-<section class="p-strip--light">
-
-  <div class="row u-equal-height">
-    <div class="col-8">
+<section class="p-strip--light is-shallow">
+  <div class="row u-equal-height  u-vertically-center">
+    <div class="col-7 suffix-1">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}31bd2627-logo-raspberry-pi.svg"  alt="Raspberry Pi">
           <h2 class="p-heading-icon__title" style="line-height: 4rem;">Ubuntu for Raspberry Pi</h2>
         </div>
       </div>
-      <p>Get the power, ease and flexibility of Ubuntu for Raspberry Pi 2 or 3.</p>
-      <p>Get started with an Ubuntu Server image for a familiar development environment.</p>
+      <p>Get the power, ease and flexibility of Ubuntu for Raspberry Pi 2 or 3.<br />
+        Get started with an Ubuntu Server image for a familiar development environment.</p>
       <p><a class="p-button--positive" href="/download/iot/raspberry-pi-2-3">Install on Raspberry Pi 2 or 3</a></p>
     </div>
-    <div class="col-4 u-vertically-center u-align--center u-hide--small">
-      <img src="{{ ASSET_SERVER_URL }}fd0fb85d-1024px-Raspberry_Pi_3_B+__39906369025_-removebg.png?w=200" width="200" alt="">
+    <div class="col-5 u-align--center u-hide--small">
+      <img src="{{ ASSET_SERVER_URL }}37373e4d-raspberry-pi.png?w=408" width="420" alt="">
     </div>
   </section>
 

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -17,7 +17,7 @@
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}31bd2627-logo-raspberry-pi.svg"  alt="Raspberry Pi">
-          <h2 class="p-heading-icon__title">Ubuntu for Raspberry Pi</h2>
+          <h2 class="p-heading-icon__title" style="line-height: 4rem;">Ubuntu for Raspberry Pi</h2>
         </div>
       </div>
       <p>Get the power, ease and flexibility of Ubuntu for Raspberry Pi 2 or 3.</p>


### PR DESCRIPTION
## Done

- Updated look of the lead Raspberry Pi strip and changed the board

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/iot](http://0.0.0.0:8001/download/iot)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the strip looks like #5004

## Issue / Card

Fixes #5003, #5004

## Screenshots

![image](https://user-images.githubusercontent.com/441217/56764706-4532e300-679d-11e9-950d-d6a763f31614.png)
