### PR TITLE
Add power and z to kubeflow contact-us

### DIFF
--- a/templates/shared/forms/interactive/_kubeflow.html
+++ b/templates/shared/forms/interactive/_kubeflow.html
@@ -55,6 +55,10 @@
             <label for="architecture-AMD">AMD</label>
             <input type="checkbox" id="architecture-Intel">
             <label for="architecture-Intel">Intel</label>
+            <input type="checkbox" id="architecture-POWER">
+            <label for="architecture-POWER">Power</label>
+            <input type="checkbox" id="architecture-Z">
+            <label for="architecture-Z">Z</label>
           </div>
         </div>
       </div>
@@ -125,7 +129,7 @@
         <h3 class="p-heading--five">Have we missed something?</h3>
         <textarea id="particular-sectors" aria-label="Have we missed something?" rows="3" placeholder="Anything extra you’d like to communicate about your needs or interests?"></textarea>
       </div>
-      <h3 class="p-heading--five">How should we get in touch?</h3>
+      <h3 class="p-heading--five">How should we stay in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
           <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm">

--- a/templates/shared/forms/interactive/_pricing-infra.html
+++ b/templates/shared/forms/interactive/_pricing-infra.html
@@ -51,8 +51,11 @@
             <label for="priority-workloads-use-cases-openstack">OpenStack</label>
             <input type="checkbox" id="priority-workloads-use-cases-kubeflow">
             <label for="priority-workloads-use-cases-kubeflow">Kubeflow</label>
-            <input type="checkbox" id="priority-workloads-use-cases-other">
-            <label for="priority-workloads-use-cases-other">Other</label>
+            <div class="js-other-container">
+              <input type="checkbox" class="js-other-container__checkbox" id="priority-workloads-use-cases-other">
+              <label for="priority-workloads-use-cases-other">Other</label>
+              <input type="text" id="priority-workloads-use-cases-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other workloads">
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Add power and z to kubeflow contact-us
- Add other box drop-down to pricing/infra contact-us

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
   - [http://0.0.0.0:8001/](http://0.0.0.0:8001/ai/install#get-in-touch)
   - [http://0.0.0.0:8001/ai/install#get-in-touch](http://0.0.0.0:8001/pricing/infra#get-in-touch)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Compare to the [kubeflow copy doc](https://docs.google.com/document/d/1PSLBJWNqWfonEfQFrWvJ4NpqCHcBoDR2wWmk8IldbOg/edit)


## Issue / Card

Fixes #5054