### PR TITLE
Update consulting to use includes

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -14,6 +14,7 @@
     <div class="col-4">
       <img src="{{ ASSET_SERVER_URL }}35515576-openstack-cloud.svg" width="323" alt="Canonical Openstack" class="u-hide--small" />
     </div>
+    <p>Choose your OpenStack package:</p>
   </div>
   {% include "shared/pricing/_openstack-packages.html" with columns='3' %}
 </section>

--- a/templates/pricing/consulting.html
+++ b/templates/pricing/consulting.html
@@ -18,49 +18,7 @@
       <h2 id="openstack">OpenStack</h2>
     </div>
     <div class="row u-equal-height">
-      <div class="col-6 p-card">
-        <div class="p-card__header">
-          <h2 class="p-heading--four">Private Cloud Build</h2>
-          <p><span class="p-heading--two">$75,000</span><br />Reference architecture deployment on 12+ nodes.</p>
-        </div>
-        <p>Two-week delivery of a highly available OpenStack on your certified hardware and in your data center.</p>
-        <p>What&rsquo;s included:</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">Hardware guidance and sizing</li>
-          <li class="p-list__item is-ticked">Fixed-price deployment</li>
-          <li class="p-list__item is-ticked">Reference architecture</li>
-          <li class="p-list__item is-ticked">Open source storage</li>
-          <li class="p-list__item is-ticked">Simplified networking</li>
-          <li class="p-list__item is-ticked">Hyper-converged</li>
-          <li class="p-list__item is-ticked">Containerised control plane</li>
-          <li class="p-list__item is-ticked">Log aggregation</li>
-          <li class="p-list__item is-ticked">Monitoring cluster</li>
-          <li class="p-list__item is-ticked">Upgrades on demand</li>
-          <li class="p-list__item is-ticked">High availability</li>
-        </ul>
-      </div>
-      <div class="col-6 p-card">
-        <div class="p-card__header">
-          <h2 class="p-heading--four">Private Cloud Build Plus</h2>
-          <p><span class="p-heading--two">$150,000</span><br />Custom architecture for your specific industry or workload requirements.</p>
-        </div>
-        <p>Co-designed workshops to determine the optimal architecture for your workloads and integration requirements. Our engineers then deploy it for you.</p>
-        <p>What&rsquo;s included:</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">Workload analysis</li>
-          <li class="p-list__item is-ticked">VMware migration plan</li>
-          <li class="p-list__item is-ticked">Customised architecture</li>
-          <li class="p-list__item is-ticked">Containerised or isolated control plane</li>
-          <li class="p-list__item is-ticked">Storage and SDN integration</li>
-          <li class="p-list__item is-ticked">LDAP or Active Directory</li>
-          <li class="p-list__item is-ticked">Corporate monitoring</li>
-          <li class="p-list__item is-ticked">Telco VNF onboarding</li>
-          <li class="p-list__item is-ticked">GPGPU and FPGA passthrough</li>
-          <li class="p-list__item is-ticked">HPC optimisation</li>
-          <li class="p-list__item is-ticked">Regulatory compliance</li>
-          <li class="p-list__item is-ticked">High availability</li>
-        </ul>
-      </div>
+      {% include "shared/pricing/_openstack-packages.html" with columns='2' %}
     </div>
     <div class="row">
       <a href="/support/contact-us?product=openstack" class="js-invoke-modal p-button--positive">Get in touch</a>
@@ -71,96 +29,14 @@
     <div class="row">
       <h2 id="kubernetes">Kubernetes</h2>
     </div>
-    <div class="row u-equal-height">
-      <div class="col-4 p-card">
-        <div class="p-card__header">
-          <h2 class="p-heading--four">Explorer</h2>
-          <p><span class="p-heading--two">$19,500</span><br />Basic workshop</p>
-        </div>
-        <p>Three-day training on Kubernetes deployment and operations. Ramp up team on Kubernetes and enable your team to deploy on VMware and public clouds.</p>
-        <p>What&rsquo;s included:</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">K8s and container basics</li>
-          <li class="p-list__item is-ticked">Reference architecture</li>
-          <li class="p-list__item is-ticked">Multi-cloud approach</li>
-          <li class="p-list__item is-ticked">Security and patching</li>
-          <li class="p-list__item is-ticked">Monitoring and logging</li>
-          <li class="p-list__item is-ticked">Lifecycle management</li>
-          <li class="p-list__item is-ticked">Backup and recovery</li>
-        </ul>
-      </div>
-      <div class="col-4 p-card">
-        <div class="p-card__header">
-          <h2 class="p-heading--four">Discoverer</h2>
-          <p><span class="p-heading--two">$45,000</span><br />Workshop and reference architecture</p>
-        </div>
-        <p>Three-day training plus five days of deployment of a reference k8s architecture on VMware, private and public clouds.</p>
-        <p>What&rsquo;s included:</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">High availability</li>
-          <li class="p-list__item is-ticked">Cloud, VMware, OpenStack</li>
-          <li class="p-list__item is-ticked">Logging, monitoring,  alerting</li>
-          <li class="p-list__item is-ticked">Calico, Canal, Flannel</li>
-          <li class="p-list__item is-ticked">Three days standard training</li>
-        </ul>
-      </div>
-      <div class="col-4 p-card">
-        <div class="p-card__header">
-          <h2 class="p-heading--four">Discoverer Plus</h2>
-          <p><span class="p-heading--two">$95,000</span><br />Training, co-design and full enterprise production deployment</p>
-        </div>
-        <p>Three weeks including on-site training, design and implementation of a custom architecture across bare metal, virtual and cloud environments.</p>
-        <p>What&rsquo;s included:</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">High availability</li>
-          <li class="p-list__item is-ticked">Logging, monitoring, alerting</li>
-          <li class="p-list__item is-ticked">Cloud, VMware, OpenStack</li>
-          <li class="p-list__item is-ticked">Bare metal</li>
-          <li class="p-list__item is-ticked">GPU acceleration</li>
-          <li class="p-list__item is-ticked">Persistent storage volumes</li>
-          <li class="p-list__item is-ticked">Hands-on in-person knowledge transfer</li>
-        </ul>
-      </div>
-    </div>
-    <div class="row">
-      <a href="/support/contact-us?product=kubernetes" class="js-invoke-modal p-button--positive">Get in touch</a>
-    </div>
+    {% include 'shared/pricing/_kubernetes-consulting.html' %}
   </section>
 
   <section class="p-strip--light">
     <div class="row">
       <h2 id="kubeflow">Kubeflow</h2>
-      <div class="col-12 p-card">
-        <div class="p-card__header">
-          <h2 class="p-heading--four">AI/ML pipelines and workflows on Kubernetes</h2>
-          <p><span class="p-heading--two">$40,000</span><br /><strong>Data science add-on to K8s Discoverer or Discoverer Plus.</strong> Workshop and readiness assessment covering machine learning using Kubeflow on Kubernetes for model training and analytics. Includes GPGPU and FPGA integration for hardware data science acceleration on k8s.</p>
-        </div>
-        <div class="row p-divider">
-          <div class="col-6 p-divider__block">
-            <h3>Workshop</h3>
-            <p>One week workshop dedicated to Kubeflow, including JupyterHub covering everything your business needs for on-prem/off-prem AI/ML operations.</p>
-            <ul class="p-list">
-              <li class="p-list__item is-ticked">On-site or remote options</li>
-              <li class="p-list__item is-ticked">Hands-on Kubernetes and Kubeflow training</li>
-              <li class="p-list__item is-ticked">Framework of choice: TensorFlow, PyTorch, Pachyderm, Seldon Core</li>
-              <li class="p-list__item is-ticked">Full pipeline view</li>
-            </ul>
-          </div>
-          <div class="col-6 p-divider__block">
-            <h3>Assessment</h3>
-            <p>Determine the readiness of your existing data science approach and capabilities.</p>
-            <ul class="p-list">
-              <li class="p-list__item is-ticked">Understand AI lifecycle</li>
-              <li class="p-list__item is-ticked">Preliminary data and process discovery</li>
-              <li class="p-list__item is-ticked">Development capacity assessment</li>
-              <li class="p-list__item is-ticked">Deploy and operate ML analysis</li>
-              <li class="p-list__item is-ticked">Finalise initial AI strategy</li>
-            </ul>
-          </div>
-        </div>
-      </div>
-      <p><a href="/support/contact-us?product=kubeflow" class="js-invoke-modal p-button--positive">Get in touch</a></p>
     </div>
+    {% include "shared/pricing/_kubernetes-consulting-add-ons.html" %}
   </section>
 
   {% include "shared/contextual_footers/_contextual_footer.html" with first_item="_support_landscape" second_item="_support_contact_us" third_item="_further_reading" %}

--- a/templates/shared/pricing/_kubernetes-consulting-add-ons.html
+++ b/templates/shared/pricing/_kubernetes-consulting-add-ons.html
@@ -1,20 +1,23 @@
 <div class="row">
-  <div class="p-card">
-    <div class="col-12 p-card__header">
-      <h2 class="p-heading--four">AI/ML Add-on</h2>
-      <p><span class="p-heading--two">$40,000</span><br />Specialised AI/ML workshop and readiness assessment</p>
+  <div class="col-12 p-card">
+    <div class="p-card__header">
+      <h2 class="p-heading--four">AI/ML pipelines and workflows on Kubernetes</h2>
+      <p><span class="p-heading--two">$40,000</span><br /><strong>Data science add-on to K8s Discoverer or Discoverer Plus.</strong> Workshop and readiness assessment covering machine learning using Kubeflow on Kubernetes for model training and analytics. Includes GPGPU and FPGA integration for hardware data science acceleration on k8s.</p>
     </div>
-    <div class="row">
-      <div class="col-6">
-        <p>One week additional workshop dedicated to Kubeflow, including JupyterHub and your kubeflow-integrated frameworks of choice (e.g. TensorFlow, PyTorch, Pachyderm, Seldon Core, etc.), covering everything your business needs for on-prem/off-prem AI/ML operations.</p>
+    <div class="row p-divider">
+      <div class="col-6 p-divider__block">
+        <h3>Workshop</h3>
+        <p>One week workshop dedicated to Kubeflow, including JupyterHub covering everything your business needs for on-prem/off-prem AI/ML operations.</p>
         <ul class="p-list">
-          <li class="p-list__item is-ticked">On site or remote options</li>
+          <li class="p-list__item is-ticked">On-site or remote options</li>
           <li class="p-list__item is-ticked">Hands-on Kubernetes and Kubeflow training</li>
+          <li class="p-list__item is-ticked">Framework of choice: TensorFlow, PyTorch, Pachyderm, Seldon Core</li>
           <li class="p-list__item is-ticked">Full pipeline view</li>
         </ul>
       </div>
-      <div class="col-6">
-        <p>Canonical and a data science partner will deliver an AI assessment as part of the workshop to help you determine the readiness of your existing approaches and capabilities for data science.</p>
+      <div class="col-6 p-divider__block">
+        <h3>Assessment</h3>
+        <p>Determine the readiness of your existing data science approach and capabilities.</p>
         <ul class="p-list">
           <li class="p-list__item is-ticked">Understand AI lifecycle</li>
           <li class="p-list__item is-ticked">Preliminary data and process discovery</li>
@@ -24,6 +27,6 @@
         </ul>
       </div>
     </div>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a></p>
   </div>
+  <p><a href="/support/contact-us?product=kubeflow" class="js-invoke-modal p-button--positive">Get in touch</a></p>
 </div>

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -1,57 +1,54 @@
 <div class="row u-equal-height">
-  <div class="col-6 p-card">
+  <div class="col-4 p-card">
     <div class="p-card__header">
-      <h2 class="p-heading--four">Kubernetes Explorer</h2>
+      <h2 class="p-heading--four">Explorer</h2>
       <p><span class="p-heading--two">$19,500</span><br />Basic workshop</p>
     </div>
-    <p>Three-day training on Kubernetes deployment and operations, helping you ramp up your Kubernetes skills and enable you to deploy in your own environment and public clouds.</p>
+    <p>Three-day training on Kubernetes deployment and operations. Ramp up team on Kubernetes and enable your team to deploy on VMware and public clouds.</p>
     <p>What&rsquo;s included:</p>
     <ul class="p-list">
-      <li class="p-list__item is-ticked">Kubernetes and Container basics</li>
+      <li class="p-list__item is-ticked">K8s and container basics</li>
       <li class="p-list__item is-ticked">Reference architecture</li>
-      <li class="p-list__item is-ticked">Deployment on multiple substrates</li>
+      <li class="p-list__item is-ticked">Multi-cloud approach</li>
       <li class="p-list__item is-ticked">Security and patching</li>
       <li class="p-list__item is-ticked">Monitoring and logging</li>
       <li class="p-list__item is-ticked">Lifecycle management</li>
       <li class="p-list__item is-ticked">Backup and recovery</li>
     </ul>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-explorer" class="js-invoke-modal">Contact us about Kubernetes Explorer&nbsp;&rsaquo;</a></p>
   </div>
-  <div class="col-6 p-card">
+  <div class="col-4 p-card">
     <div class="p-card__header">
-      <h2 class="p-heading--four">Kubernetes Discoverer</h2>
-      <p><span class="p-heading--two">$45,000</span><br />Workshop and custom architecture</p>
+      <h2 class="p-heading--four">Discoverer</h2>
+      <p><span class="p-heading--two">$45,000</span><br />Workshop and reference architecture</p>
     </div>
-    <p>Week-long training and workshop together with design of a customised architecture to fit your requirements, including deploying on virtualised environments, private and public clouds.</p>
+    <p>Three-day training plus five days of deployment of a reference k8s architecture on VMware, private and public clouds.</p>
     <p>What&rsquo;s included:</p>
     <ul class="p-list">
-      <li class="p-list__item is-ticked">High availability Kubernetes, deployed on Public Cloud, VMware, OpenStack</li>
-      <li class="p-list__item is-ticked">Custom Kubernetes architecture optimised for your workloads</li>
-      <li class="p-list__item is-ticked">Calico, Canal, Flannel networking</li>
-      <li class="p-list__item is-ticked">3 days on-site in-person Canonical Kubernetes training</li>
-      <li class="p-list__item is-ticked">Optional add-on: AI/ML $40,000 one-off fee</li>
+      <li class="p-list__item is-ticked">High availability</li>
+      <li class="p-list__item is-ticked">Cloud, VMware, OpenStack</li>
+      <li class="p-list__item is-ticked">Logging, monitoring,  alerting</li>
+      <li class="p-list__item is-ticked">Calico, Canal, Flannel</li>
+      <li class="p-list__item is-ticked">Three days standard training</li>
     </ul>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer" class="js-invoke-modal">Contact us about Kubernetes Discoverer&nbsp;&rsaquo;</a></p>
   </div>
-  <div class="col-6 p-card">
+  <div class="col-4 p-card">
     <div class="p-card__header">
-      <h2 class="p-heading--four">Kubernetes Discoverer Plus</h2>
-      <p><span class="p-heading--two">$95,000</span><br />Full enterprise deployment package</p>
+      <h2 class="p-heading--four">Discoverer Plus</h2>
+      <p><span class="p-heading--two">$95,000</span><br />Training, co-design and full enterprise production deployment</p>
     </div>
-    <p>Onsite training, design and implementation of a custom architecture across bare metal, virtual and cloud environments. Create an optimised production-grade Kubernetes cluster with a wide range of capabilities from the open K8s ecosystem to fit your requirements.</p>
+    <p>Three weeks including on-site training, design and implementation of a custom architecture across bare metal, virtual and cloud environments.</p>
     <p>What&rsquo;s included:</p>
     <ul class="p-list">
-      <li class="p-list__item is-ticked">High availability production-grade Kubernetes, deployed on Public Cloud, VMware, OpenStack, or Bare metal</li>
+      <li class="p-list__item is-ticked">High availability</li>
+      <li class="p-list__item is-ticked">Logging, monitoring, alerting</li>
+      <li class="p-list__item is-ticked">Cloud, VMware, OpenStack</li>
+      <li class="p-list__item is-ticked">Bare metal</li>
       <li class="p-list__item is-ticked">GPU acceleration</li>
-      <li class="p-list__item is-ticked">Storage for persistent volumes</li>
-      <li class="p-list__item is-ticked">Custom Networking options</li>
-      <li class="p-list__item is-ticked">Management platform</li>
-      <li class="p-list__item is-ticked">Private Registry</li>
-      <li class="p-list__item is-ticked">Load balancers</li>
-      <li class="p-list__item is-ticked">Security</li>
-      <li class="p-list__item is-ticked">Application Catalog</li>
-      <li class="p-list__item is-ticked">2 days on-site in-person Knowledge Transfer to Kubernetes Operators</li>
+      <li class="p-list__item is-ticked">Persistent storage volumes</li>
+      <li class="p-list__item is-ticked">Hands-on in-person knowledge transfer</li>
     </ul>
-    <p><a href="/kubernetes/contact-us?product=kubernetes-discoverer-plus" class="js-invoke-modal">Contact us about Kubernetes Discoverer Plus&nbsp;&rsaquo;</a></p>
   </div>
+</div>
+<div class="row">
+  <a href="/support/contact-us?product=kubernetes" class="js-invoke-modal p-button--positive">Get in touch</a>
 </div>

--- a/templates/shared/pricing/_openstack-packages.html
+++ b/templates/shared/pricing/_openstack-packages.html
@@ -1,14 +1,11 @@
-<div class="row">
-  <p>Choose your OpenStack package:</p>
-</div>
-
 <div class="row u-equal-height">
   <div class="col-6 p-card">
     <div class="p-card__header">
-      <h2 class="p-heading--four">OpenStack Build</h2>
-      <p><span class="p-heading--two">$75,000</span> with two week delivery</p>
+      <h2 class="p-heading--four">Private Cloud Build</h2>
+      <p><span class="p-heading--two">$75,000</span><br />Reference architecture deployment on 12+ nodes.</p>
     </div>
-    <p>Design and deployment of OpenStack reference architecture.</p>
+    <p>Two-week delivery of a highly available OpenStack on your certified hardware and in your data center.</p>
+    <p>What&rsquo;s included:</p>
     <ul class="p-list">
       <li class="p-list__item is-ticked">Hardware guidance and sizing</li>
       <li class="p-list__item is-ticked">Fixed-price deployment</li>
@@ -22,15 +19,14 @@
       <li class="p-list__item is-ticked">Upgrades on demand</li>
       <li class="p-list__item is-ticked">High availability</li>
     </ul>
-    <p>Two week delivery on certified hardware.</p>
-    <p><a href="/openstack/consulting">Get OpenStack&nbsp;&rsaquo;</a></p>
   </div>
   <div class="col-6 p-card">
     <div class="p-card__header">
-      <h2 class="p-heading--four">OpenStack Build Plus</h2>
-      <p><span class="p-heading--two">$150,000</span> one-time fee</p>
+      <h2 class="p-heading--four">Private Cloud Build Plus</h2>
+      <p><span class="p-heading--two">$150,000</span><br />Custom architecture for your specific industry or workload requirements.</p>
     </div>
-    <p>Additional OpenStack consulting packages for our OpenStack Build Plus service.</p>
+    <p>Co-designed workshops to determine the optimal architecture for your workloads and integration requirements. Our engineers then deploy it for you.</p>
+    <p>What&rsquo;s included:</p>
     <ul class="p-list">
       <li class="p-list__item is-ticked">Workload analysis</li>
       <li class="p-list__item is-ticked">VMware migration plan</li>
@@ -41,11 +37,10 @@
       <li class="p-list__item is-ticked">Corporate monitoring</li>
       <li class="p-list__item is-ticked">Telco VNF onboarding</li>
       <li class="p-list__item is-ticked">GPGPU and FPGA passthrough</li>
-      <li class="p-list__item is-ticked">HPC optimisations</li>
+      <li class="p-list__item is-ticked">HPC optimisation</li>
       <li class="p-list__item is-ticked">Regulatory compliance</li>
+      <li class="p-list__item is-ticked">High availability</li>
     </ul>
-    <p>On site workshops determine the optimal architecture for your workloads and integration requirements.</p>
-    <p><a href="/openstack/consulting/">Migrate from VMware&nbsp;&rsaquo;</a></p>
   </div>
   {% if columns == '3' %}
   <div class="col-6 p-card">


### PR DESCRIPTION
## Done

- Update includes and use them to update /openstack, /openstack/consulting, and /kubernetes to be the same as /pricing/consulting

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
    - http://0.0.0.0:8001/openstack
    - http://0.0.0.0:8001/openstack/consulting
    - http://0.0.0.0:8001/kubernetes
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)

Fixes #5059 
