### PR TITLE
Update PR Template to point at updated QA link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 - Check out this feature branch
 - Run the site using the command `./run serve`
 - View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
-- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
+- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
 - [List additional steps to QA the new features or prove the bug has been resolved]
 
 


### PR DESCRIPTION
## Done

Update PR Template to point at updated QA link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- Check code and ensure new link is correct to fix the step above ^
