### PR TITLE
Add devops iot webinar takeover and landing page

### DIFF
--- a/templates/engage/devops-iot-webinar.html
+++ b/templates/engage/devops-iot-webinar.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="The transformation of the DevOps journey in IoT" subtitle="Learn how Ubuntu Core and snaps can accelerate the Linux development cycle in IoT." url="#register-section" cta="Register for the webinar" class="p-strip--dark p-takeover--devops"%}
+{% include "engage/shared/_header.html" with title="The transformation of the DevOps journey in IoT" url="#register-section" cta="Register for the webinar" class="p-strip--dark p-takeover--devops"%}
 
 <section class="p-strip is-shallow is-bordered">
   <div class="row">

--- a/templates/engage/devops-iot-webinar.html
+++ b/templates/engage/devops-iot-webinar.html
@@ -1,0 +1,53 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}The transformation of the DevOps journey in IoT{% endblock %}
+
+{% block meta_description %}Traditional development methods do not scale into the IoT sphere{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1P7tOkSQZwh0vcHUMp2X2wPvGUQORktNRLjPXhrTakF8/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="The transformation of the DevOps journey in IoT" subtitle="Learn how Ubuntu Core and snaps can accelerate the Linux development cycle in IoT." image="f3d518db-devops-iot.svg" url="https://www.brighttalk.com/webcast/6793/355702?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Ubuntu Core_WBN_DevOpsJourney" cta="Register for the webinar" class="p-strip--dark p-takeover--devops"%}
+
+<section class="p-strip is-shallow is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <p>
+        Traditional development methods do not scale into the IoT sphere. Strong inter-dependencies and blurred boundaries among components in the edge device stack result in fragmentation, slow updates, security issues, increased cost, and reduced reliability of platforms.
+      </p>
+      <p>
+        This reality places a major strain on IoT players who need to contend with varying cycles and priorities in the development stack, limiting their flexibility to innovate and introduce changes into their products, both on the hardware and software sides. 
+      </p>
+      <p>
+        One notable way to reduce the complexity in multi-component stacks is through the use of DevOps - a paradigm that combines development with operations in a single and streamlined process. However, DevOps alone cannot solve the complexity and dependency that exists in monolithic IoT products.
+      </p>
+      <h4>
+        Highlights of this webinar include: 
+      </h4>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">
+          How the decoupling of components in a reliable and predictable fashion will reduce the inter-dependency, improve security and allow for faster development cycles.         </li>
+        <li class="p-list__item is-ticked">
+          A look at the technical architecture of Ubuntu Core and snaps in the context of an IoT DevOps model. 
+        </li>
+        <li class="p-list__item is-ticked">
+          Real life case studies of accelerated Linux development cycles as an alternative to the existing model. 
+        </li>
+      </ul>
+    </div>
+  </div>
+  <style>
+    .p-takeover--devops {
+      background-image: linear-gradient(134deg, #111111 0%, #212121 100%);
+    }
+  </style>
+</section>
+
+<section class="p-strip is-shallow" id="register-section">
+  <div class="row">
+      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 355702, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+  </div>
+</section>
+
+  {% endblock content %}

--- a/templates/engage/devops-iot-webinar.html
+++ b/templates/engage/devops-iot-webinar.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="The transformation of the DevOps journey in IoT" subtitle="Learn how Ubuntu Core and snaps can accelerate the Linux development cycle in IoT." image="f3d518db-devops-iot.svg" url="https://www.brighttalk.com/webcast/6793/355702?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Ubuntu Core_WBN_DevOpsJourney" cta="Register for the webinar" class="p-strip--dark p-takeover--devops"%}
+{% include "engage/shared/_header.html" with title="The transformation of the DevOps journey in IoT" subtitle="Learn how Ubuntu Core and snaps can accelerate the Linux development cycle in IoT." url="#register-section" cta="Register for the webinar" class="p-strip--dark p-takeover--devops"%}
 
 <section class="p-strip is-shallow is-bordered">
   <div class="row">

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,6 +32,7 @@
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
+  {% include "takeovers/_devops-iot-webinar_takeover.html" %}
   {% include "takeovers/_openstack_security_takeover.html" %}
   {% include "takeovers/_1904-takeover.html" %}
   {% include "takeovers/_ci-cd-webinar.html" %}

--- a/templates/takeovers/_devops-iot-webinar_takeover.html
+++ b/templates/takeovers/_devops-iot-webinar_takeover.html
@@ -2,13 +2,13 @@
     <div class="row u-clearfix u-vertically-center">
       <div class="col-8">
         <h1>The transformation of the DevOps journey in IoT</h1>
-        <h4 class="u-sv2">
+        <p class="p-heading--four u-sv2">
           Learn how Ubuntu Core and snaps can accelerate the Linux development cycle in IoT.
-        </h4>
+        </p>
         <a
-          href="https://www.brighttalk.com/webcast/6793/355702?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Ubuntu Core_WBN_DevOpsJourney"
+          href="/engage/devops-iot-webinar"
           class="p-button--positive u-hide--small"
-          ><span>Register for the webinar</span>
+          >Register for the webinar
         </a>
       </div>
       <div class="col-4">
@@ -20,9 +20,9 @@
         </p>
         <p class="u-hide--medium u-hide--large">
           <a
-            href="https://www.brighttalk.com/webcast/6793/355702?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Ubuntu Core_WBN_DevOpsJourney"
+            href="/engage/devops-iot-webinar"
             class="p-button--positive"
-            ><span>Register for the webinar</span>
+            >Register for the webinar
           </a>
         </p>
       </div>

--- a/templates/takeovers/_devops-iot-webinar_takeover.html
+++ b/templates/takeovers/_devops-iot-webinar_takeover.html
@@ -1,6 +1,6 @@
-<section class="p-strip--dark p-takeover js-takeover">
+<section class="p-strip--dark is-shallow p-takeover js-takeover">
     <div class="row u-clearfix u-vertically-center">
-      <div class="col-8">
+      <div class="col-6">
         <h1>The transformation of the DevOps journey in IoT</h1>
         <p class="p-heading--four u-sv2">
           Learn how Ubuntu Core and snaps can accelerate the Linux development cycle in IoT.
@@ -11,7 +11,7 @@
           >Register for the webinar
         </a>
       </div>
-      <div class="col-4">
+      <div class="col-6">
         <p class="p-takeover__image u-align-text--center">
           <img
             src="{{ ASSET_SERVER_URL }}f3d518db-devops-iot.svg"
@@ -29,12 +29,12 @@
     </div>
     <style>
       .p-takeover {
-        background-image: url("{{ ASSET_SERVER_URL }}69d263b9-left.svg"),
-          url("{{ ASSET_SERVER_URL }}c6f9e52d-right.svg"),
+        background-image: url("{{ ASSET_SERVER_URL }}69d263b9-left.svg"),url("{{ ASSET_SERVER_URL }}373a184b-right-top.svg"),
+          url("{{ ASSET_SERVER_URL }}d4059d66-right-bottom.svg"),
           linear-gradient(134deg, #111111 0%, #212121 100%);
-        background-position: left, right;
-        background-repeat: no-repeat, no-repeat;
-        background-size: auto 100%, auto 100%, cover;
+        background-position: left, right, right;
+        background-repeat: no-repeat, no-repeat, no-repeat;
+        background-size: auto 100%, auto 100%, auto 100%, cover;
       }
       @media (max-width: 874px) {
         .p-takeover {

--- a/templates/takeovers/_devops-iot-webinar_takeover.html
+++ b/templates/takeovers/_devops-iot-webinar_takeover.html
@@ -1,6 +1,6 @@
 <section class="p-strip--dark is-shallow p-takeover js-takeover">
     <div class="row u-clearfix u-vertically-center">
-      <div class="col-6">
+      <div class="col-7">
         <h1>The transformation of the DevOps journey in IoT</h1>
         <p class="p-heading--four u-sv2">
           Learn how Ubuntu Core and snaps can accelerate your development cycle.
@@ -11,7 +11,7 @@
           >Register for the webinar
         </a>
       </div>
-      <div class="col-6">
+      <div class="col-5">
         <p class="p-takeover__image u-align-text--center">
           <img
             src="{{ ASSET_SERVER_URL }}f3d518db-devops-iot.svg"

--- a/templates/takeovers/_devops-iot-webinar_takeover.html
+++ b/templates/takeovers/_devops-iot-webinar_takeover.html
@@ -3,7 +3,7 @@
       <div class="col-6">
         <h1>The transformation of the DevOps journey in IoT</h1>
         <p class="p-heading--four u-sv2">
-          Learn how Ubuntu Core and snaps can accelerate the Linux development cycle in IoT.
+          Learn how Ubuntu Core and snaps can accelerate your development cycle.
         </p>
         <a
           href="/engage/devops-iot-webinar"

--- a/templates/takeovers/_devops-iot-webinar_takeover.html
+++ b/templates/takeovers/_devops-iot-webinar_takeover.html
@@ -6,7 +6,7 @@
           Learn how Ubuntu Core and snaps can accelerate your development cycle.
         </p>
         <a
-          href="/engage/devops-iot-webinar"
+          href="/engage/devops-iot-webinar?utm_source=Takeover&utm_campaign=CY19_IOT_Ubuntu Core_WBN_DevOpsJourney"
           class="p-button--positive u-hide--small"
           >Register for the webinar
         </a>
@@ -20,7 +20,7 @@
         </p>
         <p class="u-hide--medium u-hide--large">
           <a
-            href="/engage/devops-iot-webinar"
+            href="/engage/devops-iot-webinar?utm_source=Takeover&utm_campaign=CY19_IOT_Ubuntu Core_WBN_DevOpsJourney"
             class="p-button--positive"
             >Register for the webinar
           </a>

--- a/templates/takeovers/_devops-iot-webinar_takeover.html
+++ b/templates/takeovers/_devops-iot-webinar_takeover.html
@@ -1,0 +1,49 @@
+<section class="p-strip--dark p-takeover js-takeover">
+    <div class="row u-clearfix u-vertically-center">
+      <div class="col-8">
+        <h1>The transformation of the DevOps journey in IoT</h1>
+        <h4 class="u-sv2">
+          Learn how Ubuntu Core and snaps can accelerate the Linux development cycle in IoT.
+        </h4>
+        <a
+          href="https://www.brighttalk.com/webcast/6793/355702?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Ubuntu Core_WBN_DevOpsJourney"
+          class="p-button--positive u-hide--small"
+          ><span>Register for the webinar</span>
+        </a>
+      </div>
+      <div class="col-4">
+        <p class="p-takeover__image u-align-text--center">
+          <img
+            src="{{ ASSET_SERVER_URL }}f3d518db-devops-iot.svg"
+            alt=""
+          />
+        </p>
+        <p class="u-hide--medium u-hide--large">
+          <a
+            href="https://www.brighttalk.com/webcast/6793/355702?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Ubuntu Core_WBN_DevOpsJourney"
+            class="p-button--positive"
+            ><span>Register for the webinar</span>
+          </a>
+        </p>
+      </div>
+    </div>
+    <style>
+      .p-takeover {
+        background-image: url("{{ ASSET_SERVER_URL }}69d263b9-left.svg"),
+          url("{{ ASSET_SERVER_URL }}c6f9e52d-right.svg"),
+          linear-gradient(134deg, #111111 0%, #212121 100%);
+        background-position: left, right;
+        background-repeat: no-repeat, no-repeat;
+        background-size: auto 100%, auto 100%, cover;
+      }
+      @media (max-width: 874px) {
+        .p-takeover {
+          background-image: linear-gradient(134deg, #111111 0%, #212121 100%);
+        }
+        .p-takeover__image {
+          width: 300px;
+        }
+      }
+    </style>
+  </section>
+  


### PR DESCRIPTION
## Done

Add devops iot webinar takeover and landing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/) and [/engage/devops-iot-webinar](http://0.0.0.0:8001/engage/devops-iot-webinar)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to the [home page](http://0.0.0.0:8001/) and refresh until this takeover comes up
- Go to [/engage/devops-iot-webinar](http://0.0.0.0:8001/engage/devops-iot-webinar) and check the landing page
- Make sure it complies with the [design](https://github.com/canonical-web-and-design/www.ubuntu.com/issues/5021)
- Make sure it complies with the [copydoc](https://docs.google.com/document/d/1P7tOkSQZwh0vcHUMp2X2wPvGUQORktNRLjPXhrTakF8/edit#)


## Issue / Card

[Fixes#5023](https://github.com/canonical-web-and-design/www.ubuntu.com/issues/5023)

