### PR TITLE
Remove border of the Japanese translation card

### DIFF
--- a/templates/legal/shared/_uasd_toc_new.html
+++ b/templates/legal/shared/_uasd_toc_new.html
@@ -23,8 +23,7 @@
 
 
 </nav>
-<nav class="p-card">
-
+<nav class="p-card--no-border">
   <h3>Japanese translation</h3>
   <ul class="p-list">
     <li class="p-list__item"><a href="/legal/ubuntu-advantage-service-description/ja">UA 略式サービス契約&nbsp;›</a></li>

--- a/templates/legal/shared/_uasd_toc_new.html
+++ b/templates/legal/shared/_uasd_toc_new.html
@@ -21,11 +21,5 @@
       <li class="p-nested-counter-list__item"><a href="#uasd-definitions">Definitions</a></li>
   </ol>
 
+</nav>
 
-</nav>
-<nav class="p-card--no-border">
-  <h3>Japanese translation</h3>
-  <ul class="p-list">
-    <li class="p-list__item"><a href="/legal/ubuntu-advantage-service-description/ja">UA 略式サービス契約&nbsp;›</a></li>
-  </ul>
-</nav>


### PR DESCRIPTION
## Done

Remove japanese UASD box from /uasd

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/legal/ubuntu-advantage-service-description](http://0.0.0.0:8001/legal/ubuntu-advantage-service-description)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure the box to the Japanese translation is removed [issue #5063](https://github.com/canonical-web-and-design/www.ubuntu.com/issues/5063)


## Issue / Card

[Fixes #5063](https://github.com/canonical-web-and-design/www.ubuntu.com/issues/5063)

## Screenshots
![image](https://user-images.githubusercontent.com/40214246/56954344-76f9d000-6b36-11e9-83ce-652df9e5896c.png)


