### PR TITLE
Change copydoc link

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -1,7 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Get Ubuntu | Download{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1kp7QQXst1EbCjZjzWZP3YZwfmG0EIXLfQoRUVaMEZng/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1egsCcmFiz8czeHsvwoB9Jz815Ij5Urtf7Ngrru6Zd4o/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <div class="p-strip is-shallow">


### PR DESCRIPTION
## Done

Change copydoc link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download](http://0.0.0.0:8001/download)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure the [copydoc](https://github.com/canonical-web-and-design/www.ubuntu.com/issues/5035) link has been updated

## Issue / Card

[Fixes #5035](https://github.com/canonical-web-and-design/www.ubuntu.com/issues/5035)
