### PR TITLE
Update release chart on /server page

### DIFF
--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -194,10 +194,12 @@ function formatKeyLabel(key) {
  * Builds chart using supplied selector and data
  */
 export function createChart(chartSelector, taskTypes, taskStatus, tasks) {
-  var chartSelectorElement = document.querySelector(chartSelector)
-  if (!chartSelectorElement) {
-    return
-  }
+  var chartSelectorElement = document.querySelector(chartSelector);
+  console.log(chartSelectorElement);
+  console.log(chartSelectorElement.clientWidth);
+  // if (!chartSelectorElement) {
+  //   return
+  // }
   var margin = {
     top: 0,
     right: 40,
@@ -208,7 +210,7 @@ export function createChart(chartSelector, taskTypes, taskStatus, tasks) {
   var timeDomainStart = d3.time.year.offset(tasks[0].startDate, -1);
   var timeDomainEnd = d3.time.year.offset(tasks[tasks.length - 1].endDate, +1);
   var height = taskTypes.length * rowHeight;
-  var width = chartSelectorElement.clientWidth - margin.right - margin.left;
+  var width = document.querySelector(chartSelector).clientWidth - margin.right - margin.left;
 
   var x = d3.time
     .scale()

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -194,12 +194,6 @@ function formatKeyLabel(key) {
  * Builds chart using supplied selector and data
  */
 export function createChart(chartSelector, taskTypes, taskStatus, tasks) {
-  var chartSelectorElement = document.querySelector(chartSelector);
-  console.log(chartSelectorElement);
-  console.log(chartSelectorElement.clientWidth);
-  // if (!chartSelectorElement) {
-  //   return
-  // }
   var margin = {
     top: 0,
     right: 40,

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -194,6 +194,10 @@ function formatKeyLabel(key) {
  * Builds chart using supplied selector and data
  */
 export function createChart(chartSelector, taskTypes, taskStatus, tasks) {
+  var chartSelectorElement = document.querySelector(chartSelector)
+  if (!chartSelectorElement) {
+    return
+  }
   var margin = {
     top: 0,
     right: 40,
@@ -204,7 +208,7 @@ export function createChart(chartSelector, taskTypes, taskStatus, tasks) {
   var timeDomainStart = d3.time.year.offset(tasks[0].startDate, -1);
   var timeDomainEnd = d3.time.year.offset(tasks[tasks.length - 1].endDate, +1);
   var height = taskTypes.length * rowHeight;
-  var width = document.querySelector(chartSelector).clientWidth - margin.right - margin.left;
+  var width = chartSelectorElement.clientWidth - margin.right - margin.left;
 
   var x = d3.time
     .scale()

--- a/static/js/release-chart.js
+++ b/static/js/release-chart.js
@@ -44,8 +44,15 @@ function clearCharts() {
 
 var mediumBreakpoint = 768;
 
+// A bit of a hack, but chart doesn't load with full year axis on first load,
+// It has to be loaded once, and then again
+// This will need looking into but this fix will work for now
 if (window.innerWidth >= mediumBreakpoint) {
   buildCharts();
+  setTimeout(function() {
+    clearCharts();
+    buildCharts();
+  }, 0);
 }
 
 window.addEventListener('resize', debounce(function() {

--- a/static/js/release-chart.js
+++ b/static/js/release-chart.js
@@ -29,17 +29,33 @@ function debounce(func, wait, immediate) {
 }
 
 function buildCharts() {
-  createChart('#server-desktop-eol', desktopServerReleaseNames, desktopServerStatus, serverAndDesktopReleases);
-  // createChart('#kernel-eol', kernelReleaseNames, kernelStatus, kernelReleases);
-  // createChart('#openstack-eol', openStackReleaseNames, openStackStatus, openStackReleases);
-  // createChart('#kubernetes-eol', kubernetesReleaseNames, kubernetesStatus, kubernetesReleases);
+  if (document.querySelector('#server-desktop-eol')) {
+    createChart('#server-desktop-eol', desktopServerReleaseNames, desktopServerStatus, serverAndDesktopReleases);
+  }
+  if (document.querySelector('#kernel-eol')) {
+    createChart('#kernel-eol', kernelReleaseNames, kernelStatus, kernelReleases);
+  }
+  if (document.querySelector('#openstack-eol')) {
+    createChart('#openstack-eol', openStackReleaseNames, openStackStatus, openStackReleases);
+  }
+  if (document.querySelector('#kubernetes-eol')) {
+    createChart('#kubernetes-eol', kubernetesReleaseNames, kubernetesStatus, kubernetesReleases);
+  }
 }
 
 function clearCharts() {
-  document.querySelector('#server-desktop-eol').innerHTML = '';
-  // document.querySelector('#kernel-eol').innerHTML = '';
-  // document.querySelector('#openstack-eol').innerHTML = '';
-  // document.querySelector('#kubernetes-eol').innerHTML = '';
+  if (document.querySelector('#server-desktop-eol')) {
+    document.querySelector('#server-desktop-eol').innerHTML = '';
+  }
+  if (document.querySelector('#kernel-eol')) {
+    document.querySelector('#kernel-eol').innerHTML = '';
+  }
+  if (document.querySelector('#openstack-eol')) {
+    document.querySelector('#openstack-eol').innerHTML = '';
+  }
+  if (document.querySelector('#kubernetes-eol')) {
+    document.querySelector('#kubernetes-eol').innerHTML = '';
+  }
 }
 
 var mediumBreakpoint = 768;

--- a/static/js/release-chart.js
+++ b/static/js/release-chart.js
@@ -30,16 +30,16 @@ function debounce(func, wait, immediate) {
 
 function buildCharts() {
   createChart('#server-desktop-eol', desktopServerReleaseNames, desktopServerStatus, serverAndDesktopReleases);
-  createChart('#kernel-eol', kernelReleaseNames, kernelStatus, kernelReleases);
-  createChart('#openstack-eol', openStackReleaseNames, openStackStatus, openStackReleases);
-  createChart('#kubernetes-eol', kubernetesReleaseNames, kubernetesStatus, kubernetesReleases);
+  // createChart('#kernel-eol', kernelReleaseNames, kernelStatus, kernelReleases);
+  // createChart('#openstack-eol', openStackReleaseNames, openStackStatus, openStackReleases);
+  // createChart('#kubernetes-eol', kubernetesReleaseNames, kubernetesStatus, kubernetesReleases);
 }
 
 function clearCharts() {
   document.querySelector('#server-desktop-eol').innerHTML = '';
-  document.querySelector('#kernel-eol').innerHTML = '';
-  document.querySelector('#openstack-eol').innerHTML = '';
-  document.querySelector('#kubernetes-eol').innerHTML = '';
+  // document.querySelector('#kernel-eol').innerHTML = '';
+  // document.querySelector('#openstack-eol').innerHTML = '';
+  // document.querySelector('#kubernetes-eol').innerHTML = '';
 }
 
 var mediumBreakpoint = 768;

--- a/templates/shared/_release_schedule.html
+++ b/templates/shared/_release_schedule.html
@@ -1,3 +1,5 @@
+{% load versioned_static %}
+
 <div class="p-strip--light is-deep is-bordered">
   <div class="row">
     <div class="col-12">
@@ -5,21 +7,110 @@
     </div>
   </div>
   <div class="row">
-    <div class="u-equal-height">
-      <div class="col-7">
-        <div class="u-sv3">
-          <img src="{{ ASSET_SERVER_URL }}cf53cf6c-release-ubuntu-end-of-life.png?w=592" width="592" alt="Ubuntu Desktop release cycle, 5 year long-term support" />
-        </div>
-      </div>
-      <div class="col-5">
-        <p class="p-heading--four">Stay up-to-date with regular updates and upgrades</p>
-        {% if level_1 == 'desktop' %}
-        <p>Every two years there is a new long-term support (LTS) release of Ubuntu Desktop that is supported for five years. During that time, there will be regular security fixes and other critical updates which are, and always will be, free of charge.</p>
-        {% endif %}
-        {% if level_1 == 'server' %}
-        <p>Long-term support (LTS) releases of Ubuntu Server receive security updates by Canonical for five years by default. Every six months, interim releases bring new features, while hardware enablement updates add support for the latest machines to all supported LTS releases. All <a href="/support">Ubuntu Advantage for Infrastructure subscriptions</a> include <a href="/esm">Extended Security Maintenance (ESM)</a> increasing the support life-cycle to up to 10 years.</p>
-        {% endif %}
-      </div>
+    <p class="p-heading--four">Stay up-to-date with regular updates and upgrades</p>
+    {% if level_1 == 'desktop' %}
+    <p>Every two years there is a new long-term support (LTS) release of Ubuntu Desktop that is supported for five years. During that time, there will be regular security fixes and other critical updates which are, and always will be, free of charge.</p>
+    {% endif %}
+    {% if level_1 == 'server' %}
+    <p>Long-term support (LTS) releases of Ubuntu Server receive security updates by Canonical for five years by default. Every six months, interim releases bring new features, while hardware enablement updates add support for the latest machines to all supported LTS releases. All <a href="/support">Ubuntu Advantage for Infrastructure subscriptions</a> include <a href="/esm">Extended Security Maintenance (ESM)</a> increasing the support life-cycle to up to 10 years.</p>
+    {% endif %}
+  </div>
+  <div class="row">
+    <div class="col-10" style="overflow: auto;">
+      <div class="u-hide--small" id="server-desktop-eol"></div>
+      <table class="u-hide--medium u-hide--large" style="width: auto;">
+        <thead>
+          <tr>
+            <td>&nbsp;</td>
+            <th scope="col">Released</th>
+            <th scope="col">End of Life</th>
+            <th scope="col">Extended security maintenance</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Ubuntu 22.04 LTS</strong></td>
+            <td>April 2022</td>
+            <td>April 2027</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Ubuntu 21.10</td>
+            <td>October 2021</td>
+            <td>July 2022</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Ubuntu 21.04</td>
+            <td>April 2021</td>
+            <td>January 2022</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Ubuntu 20.10</td>
+            <td>October 2020</td>
+            <td>July 2021</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04 LTS</strong></td>
+            <td>April 2020</td>
+            <td>April 2025</td>
+            <td>April 2030</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 19.10</td>
+            <td>October 2019</td>
+            <td>July 2020</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Ubuntu 19.04</td>
+            <td>April 2019</td>
+            <td>January 2020</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Ubuntu 18.10</td>
+            <td>October 2018</td>
+            <td>July 2019</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04 LTS</strong></td>
+            <td>April 2018</td>
+            <td>April 2023</td>
+            <td>April 2028</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04 LTS</strong></td>
+            <td>April 2016</td>
+            <td>April 2021</td>
+            <td>April 2024</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04 LTS</strong></td>
+            <td>April 2014</td>
+            <td>April 2019</td>
+            <td>April 2022</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 12.04 LTS</strong></td>
+            <td>April 2012</td>
+            <td>April 2017</td>
+            <td>April 2019</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 10.04 LTS</strong></td>
+            <td>April 2010</td>
+            <td>April 2015</td>
+            <td></td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+<script src="{% versioned_static 'js/build/release-chart.min.js' %}"></script>


### PR DESCRIPTION
## Done

Update release chart on /server page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/server](http://0.0.0.0:8001/server)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure the graph on [/server](http://0.0.0.0:8001/server) under "A release schedule you can depend" matches the graph on [https://www.ubuntu.com/about/release-cycle](https://www.ubuntu.com/about/release-cycle) under the "Long term support and interim releases"


## Issue / Card

[Fixes #5058](https://github.com/canonical-web-and-design/www.ubuntu.com/issues/5058)

