### PR TITLE
1117 replace old takeovers with new takeovers

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -35,8 +35,7 @@
   {% include "takeovers/_1904-takeover.html" %}
   {% include "takeovers/_openstack_security_takeover.html" %}
   {% include "takeovers/_14-04-esm.html" %}
-  <!-- Replace the takeover below -->
-  {% include "takeovers/_snap-deltas-takeover.html" %}
+  {% include "takeovers/_devops-iot-webinar_takeover.html" %}
 {% endblock takeover_content %}
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,10 +32,10 @@
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
-  {% include "takeovers/_openstack_security_takeover.html" %}
   {% include "takeovers/_1904-takeover.html" %}
-  {% include "takeovers/_ci-cd-webinar.html" %}
+  {% include "takeovers/_openstack_security_takeover.html" %}
   {% include "takeovers/_14-04-esm.html" %}
+  <!-- Replace the takeover below -->
   {% include "takeovers/_snap-deltas-takeover.html" %}
 {% endblock takeover_content %}
 


### PR DESCRIPTION
## Done

Replace old takeovers with new takeovers

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the page and make sure the old takeovers are replaced with the new ones as per [#1117](https://github.com/canonical-web-and-design/web-squad/issues/1117)


## Issue / Card

[Fixes #1117](https://github.com/canonical-web-and-design/web-squad/issues/1117)


