### PR TITLE
Add cloud-init takeover and landing page

### DIFF
--- a/templates/engage/cloud-init-whitepaper.html
+++ b/templates/engage/cloud-init-whitepaper.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="Cloud-init" image="28e89608-cloud-init.svg" url="#register-section" cta="Download the whitepaper" class="p-strip p-takeover--devops"%}
+{% include "engage/shared/_header.html" with title="Cloud-init" image="28e89608-cloud-init.svg" url="#register-section" cta="Download the whitepaper" class="p-strip--dark p-takeover--devops"%}
 
 <section class="p-strip is-shallow is-bordered">
   <div class="row">
@@ -43,7 +43,7 @@
   </div>
   <style>
     .p-takeover--devops {
-      background-image: linear-gradient(64deg, #DEDEDE 0%, #FFFFFF 100%);
+      background-image: linear-gradient(214deg, #E95420 0%, #C44631 6%, #A33940 12%, #8B304A 18%, #7C2B51 24%, #772953 29%, #55163B 51%, #370626 75%, #2C001E 89%);
     }
   </style>
 </section>

--- a/templates/engage/cloud-init-whitepaper.html
+++ b/templates/engage/cloud-init-whitepaper.html
@@ -1,0 +1,51 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Cloud-init{% endblock %}
+
+{% block meta_description %}Private cloud, public cloud, hybrid cloud, multi-cloud… the variety of locations, platforms and physical substrate you can start a cloud instance on is vast.{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1gcCaCuOdNBV8pqajXVCdAAxOTmO22cdPRD1h5j3oRbU/edit#heading=h.4ukgkign4yjt{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Cloud-init" image="28e89608-cloud-init.svg" url="#register-section" cta="Download the whitepaper" class="p-strip p-takeover--devops"%}
+
+<section class="p-strip is-shallow is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <p>
+        Private cloud, public cloud, hybrid cloud, multi-cloud… the variety of locations, platforms and physical substrate you can start a cloud instance on is vast. Yet once you have selected an operating system which best supports your application stack, you should be able to use that operating system as an abstraction layer between different clouds.
+      </p>
+      <p>
+        However, in order to function together an operating system and its cloud must share some critical configuration data which tells the operating system how to ‘behave’ in the particular environment. Separating out this configuration data from the operating system and the underlying cloud is the key to effortlessly launching instances across multi-cloud.
+      </p>
+      <p>
+        Cloud-init provides a mechanism for separating out configuration data from both the operating system and the execution environment so that you maintain the ability to change either at any time. It serves as a useful abstraction which ensures that the investments you make in your application stack on a specific operating system can be leveraged across multiple clouds.
+      </p>
+      <p class="p-heading--four">
+        This whitepaper will explain:
+      </p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">
+          The background and history behind the cloud-init open source project
+        </li>
+        <li class="p-list__item is-ticked">
+          How cloud-init is invoked and how it configures an instance
+        </li>
+        <li class="p-list__item is-ticked">
+          How to get started with cloud-init
+        </li>
+      </ul>
+    </div>
+    <div class="col-5" id="register-section">
+      {% include "../shared/forms/_landing_page_default.html" with id="3386" returnURL="https://pages.ubuntu.com/Whitepaper_CloudInit-TY.html" %}
+    </div>
+  </div>
+  <style>
+    .p-takeover--devops {
+      background-image: linear-gradient(64deg, #DEDEDE 0%, #FFFFFF 100%);
+    }
+  </style>
+</section>
+
+  {% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,6 +33,7 @@
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
   {% include "takeovers/_lxd-takeover.html" %}
+  {% include "takeovers/_openstack_security_takeover.html" %}
   {% include "takeovers/_1904-takeover.html" %}
   {% include "takeovers/_14-04-esm.html" %}
   {% include "takeovers/_devops-iot-webinar_takeover.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
-  {% include "takeovers/_lxd-takeover.html" %}
+  {% include "takeovers/_cloud-init-takeover.html" %}
   {% include "takeovers/_openstack_security_takeover.html" %}
   {% include "takeovers/_1904-takeover.html" %}
   {% include "takeovers/_14-04-esm.html" %}

--- a/templates/takeovers/_cloud-init-takeover.html
+++ b/templates/takeovers/_cloud-init-takeover.html
@@ -1,0 +1,46 @@
+<section class="p-strip--dark p-takeover js-takeover">
+  <div class="row u-clearfix u-vertically-center">
+    <div class="col-7">
+      <h1>Cloud-init</h1>
+      <p class="p-heading--four u-sv2">
+        Learn how to use cloud-init to customise, setup and configure your servers across clouds and distributions.
+      </p>
+        <a
+          href="/engage/cloud-init-whitepaper"
+          class="p-button--positive u-hide--small"
+          >Download the whitepaper
+        </a>
+     </div>
+    <div class="col-5">
+      <p class="u-align-text--center">
+        <img
+          src="{{ ASSET_SERVER_URL }}28e89608-cloud-init.svg"
+          alt=""
+        />
+      </p>
+      <p class="u-hide--medium u-hide--large">
+        <a
+          href="/engage/cloud-init-whitepaper"
+          class="p-button--positive"
+          >Download the whitepaper
+        </a
+        >
+      </p>
+    </div>
+  </div>
+  <style>
+    .p-takeover {
+      background-image: url("{{ ASSET_SERVER_URL }}dff57ac6-suru-right.png"),
+        linear-gradient(214deg, #E95420 0%, #C44631 6%, #A33940 12%, #8B304A 18%, #7C2B51 24%, #772953 29%, #55163B 51%, #370626 75%, #2C001E 89%);
+      background-position: right, right;
+      background-repeat: no-repeat;
+      background-size: auto 100%, cover;
+      
+    }
+    @media (max-width: 874px) {
+      .p-takeover {
+        background-image: linear-gradient(214deg, #E95420 0%, #C44631 6%, #A33940 12%, #8B304A 18%, #7C2B51 24%, #772953 29%, #55163B 51%, #370626 75%, #2C001E 89%);
+      }
+    }
+  </style>
+</section>

--- a/templates/takeovers/_cloud-init-takeover.html
+++ b/templates/takeovers/_cloud-init-takeover.html
@@ -6,7 +6,7 @@
         Learn how to use cloud-init to customise, setup and configure your servers across clouds and distributions.
       </p>
         <a
-          href="/engage/cloud-init-whitepaper"
+          href="/engage/cloud-init-whitepaper?utm_source=takeover&utm_campaign=CY19_DC_Server_Whitepaper_CloudInit"
           class="p-button--positive u-hide--small"
           >Download the whitepaper
         </a>

--- a/templates/takeovers/_cloud-init-takeover.html
+++ b/templates/takeovers/_cloud-init-takeover.html
@@ -20,7 +20,7 @@
       </p>
       <p class="u-hide--medium u-hide--large">
         <a
-          href="/engage/cloud-init-whitepaper"
+          href="/engage/cloud-init-whitepaper?utm_source=takeover&utm_campaign=CY19_DC_Server_Whitepaper_CloudInit"
           class="p-button--positive"
           >Download the whitepaper
         </a


### PR DESCRIPTION
## Done

Add cloud-init takeover and landing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001) and [/engage/cloud-init-whitepaper](http://0.0.0.0:8001/engage/cloud-init-whitepaper)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the [home page](http://0.0.0.0:8001) until you see the cloud-init takeover and then click the button to check the landing page
- Make sure complies with the [design](https://github.com/canonical-web-and-design/www.ubuntu.com/issues/5024)
- Make sure complies with the [brief](https://docs.google.com/document/d/1sPg4mSovCx1J0DpvBo818ulCFCgPhTRxSz8BRFF62w8/edit)


## Issue / Card

Fixes #5026

