### PR TITLE
Rename Foundation Cloud Build to Private Cloud Build

### DIFF
--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -182,7 +182,7 @@
           <h3 class="p-heading-icon__title">Consultation services</h3>
         </div>
         <p>
-          <a href="/openstack/consulting">The Foundation Cloud Build service for a fixed-price cloud built on your premises&nbsp;&rsaquo;</a>
+          <a href="/openstack/consulting">The Private Cloud Build service for a fixed-price cloud built on your premises&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>

--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -1,7 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
 {% block title %}Consulting | OpenStack{% endblock %}
-{% block meta_description %}Foundation Cloud Build is a service that builds, supports and manages your cloud for you.{% endblock meta_description %}
+{% block meta_description %}Private Cloud Build is a service that builds, supports and manages your cloud for you.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1f83OSIHVQGMjF7b0pZUKFvoubMGqi_b-OYbSpyhveX4/edit{% endblock meta_copydoc %}
 
 {% block content %}
@@ -36,10 +36,10 @@
     </div>
     <div class="row">
       <h3>From zero to private cloud &mdash; OpenStack delivery on rails</h3>
-      <p>With many years experience deploying, supporting, running and upgrading OpenStack clouds, Canonical offers a unique fixed-price private cloud delivery service with a proven reference architecture, called Foundation Cloud Build.</p>
+      <p>With many years experience deploying, supporting, running and upgrading OpenStack clouds, Canonical offers a unique fixed-price private cloud delivery service with a proven reference architecture, called Private Cloud Build.</p>
     </div>
     <div class="row u-vertically-spaced">
-      <h3 class="p-heading--four">What&rsquo;s available with Foundation Cloud Build?</h3>
+      <h3 class="p-heading--four">What&rsquo;s available with Private Cloud Build?</h3>
     </div>
     <div class="row">
       <div class="col-6">
@@ -83,7 +83,7 @@
       <div class="col-4 p-divider__block">
         <h3>Ops dashboards and monitoring included</h3>
         <p>Logging and monitoring complex distributed systems is an art form! Canonical&rsquo;s operations teams run hundreds of infrastructure subsystems and clouds, and have converged on a world-class open source monitoring stack.</p>
-        <p>Your Foundation Cloud Build comes with modern open source tools &mdash; Prometheus, ELK and Nagios &mdash; for deep insights into your infrastructure performance and health.</p>
+        <p>Your Private Cloud Build comes with modern open source tools &mdash; Prometheus, ELK and Nagios &mdash; for deep insights into your infrastructure performance and health.</p>
       </div>
       <div class="col-4 p-divider__block">
         <h3>24x7 support or outsourced operations</h3>

--- a/templates/openstack/contact-us.html
+++ b/templates/openstack/contact-us.html
@@ -34,7 +34,7 @@
 
   {% elif product == 'foundation-cloud' %}
 
-    {% include "shared/_cloud-contact-us-form.html" with  h1="Talk to us about building your cloud" intro_text="Fill in your details below and a member of our Foundation Cloud Build team will be in touch." formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud' %}
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Talk to us about building your cloud" intro_text="Fill in your details below and a member of our Private Cloud Build team will be in touch." formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud' %}
 
   {% elif product == 'openstack-german' %}
 

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -167,7 +167,7 @@
         <li class="p-list__item is-ticked">Hardware guidance</li>
       </ul>
       <p><a href="/openstack/contact-us?product=foundation-cloud" class="p-button--positive js-invoke-modal">Contact us for custom OpenStack engineering</a></p>
-      <p><a href="/openstack/consulting">Learn more about Foundation Cloud Build&nbsp;&rsaquo;</a></p>
+      <p><a href="/openstack/consulting">Learn more about Private Cloud Build&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 prefix-1">
       <blockquote class="p-pull-quote">
@@ -229,7 +229,7 @@
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Consulting packages</h3>
           <div class="p-matrix__desc">
-            <p>We offer workshops, application requirements assessment, hardware recommendations and our 2-week on-rails Foundation Cloud Build, a fixed-price OpenStack deployment service.</p>
+            <p>We offer workshops, application requirements assessment, hardware recommendations and our 2-week on-rails Private Cloud Build, a fixed-price OpenStack deployment service.</p>
             <p><a href="/openstack/consulting">Learn about our OpenStack consulting services&nbsp;&rsaquo;</a></p>
           </div>
         </div>

--- a/templates/openstack/thank-you.html
+++ b/templates/openstack/thank-you.html
@@ -20,7 +20,7 @@
 {% elif product == 'openstack-managed-cloud' or product == 'openstack-managed-cloud-demo' %}
   {% include "shared/_thank_you.html" with thanks_context="enquiring about a BootStack managed cloud" %}
 {% elif product == 'foundation-cloud' %}
-  {% include "shared/_thank_you.html" with thanks_context="enquiring about Foundation Cloud Build" %}
+  {% include "shared/_thank_you.html" with thanks_context="enquiring about Private Cloud Build" %}
 {% elif product == 'rfp' %}
   {% include "shared/_thank_you.html" with thanks_context="enquiring about your RFP" %}
 {% else %}

--- a/templates/shared/contextual_footers/_consulting_packages.html
+++ b/templates/shared/contextual_footers/_consulting_packages.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Consulting packages</h3>
-  <p>We offer workshops, application requirements assessment, hardware recommendations and our 2-week on-rails Foundation Cloud Build, a fixed-price OpenStack deployment service.</p>
+  <p>We offer workshops, application requirements assessment, hardware recommendations and our 2-week on-rails Private Cloud Build, a fixed-price OpenStack deployment service.</p>
   <p><a href="/openstack/consulting" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Consulting packages', 'eventLabel' : 'Learn about our OpenStack consulting services', 'eventValue' : undefined });">Learn about our OpenStack consulting services&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -69,7 +69,7 @@
     <div class="col-6 p-card--highlighted">
       <h2 class="p-card__title">NFVI cloud build</h2>
       <div class="p-card__content">
-        <p>Canonical&rsquo;s Foundation Cloud Build for telcos is a pre-tested, pre-integrated OpenStack cloud built using a proven reference architecture and tailored to the needs of CSPs.</p>
+        <p>Canonical&rsquo;s Private Cloud Build for telcos is a pre-tested, pre-integrated OpenStack cloud built using a proven reference architecture and tailored to the needs of CSPs.</p>
         <p>Think of it as a fixed price, NFV-ready cloud, deployed by Canonical on your premises in just a few weeks.</p>
         <p><a href="/openstack/consulting">Find out more<span class="u-off-screen"> about NFVI cloud build</span>&nbsp;&rsaquo;</a></p>
       </div>


### PR DESCRIPTION
## Done

- Rename Foundation Cloud Build to Private Cloud Build

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
    - http://0.0.0.0:8001/financial-services/
    - http://0.0.0.0:8001/openstack/consulting
    - http://0.0.0.0:8001/openstack/contact-us
    - http://0.0.0.0:8001/openstack/
    - http://0.0.0.0:8001/openstack/thank-you
    - http://0.0.0.0:8001/telecommunications/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the name has been changed

## Issue / Card

Fixes #5075