### PR TITLE
Promote multipass run

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -12,44 +12,38 @@
   </div>
 </div>
 
-<div class="p-strip u-no-padding--top u-no-padding--bottom">
+<div class="p-strip u-no-padding--top">
 
-  <div class="row">
-    <div class="col-12">
-      <div class="p-card">
-        <h2 class="p-card__title"><a href="/download/desktop">Ubuntu Desktop&nbsp;&rsaquo;</a></h2>
-        <p class="p-card__content">Download Ubuntu desktop and replace your current operating system whether it&rsquo;s Windows or Mac OS, or, run Ubuntu alongside it.</p>
-        <hr class="u-sv1">
-        <p class="u-no-margin--bottom"><strong>Do you want to upgrade?</strong> <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop">Follow our simple guide</a>
-      </div>
+  <div class="row u-equal-height">
+    <div class="p-card col-6">
+      <h2 class="p-card__title"><a href="/download/desktop">Ubuntu Desktop&nbsp;&rsaquo;</a></h2>
+      <p class="p-card__content">Download Ubuntu desktop and replace your current operating system whether it&rsquo;s Windows or Mac OS, or, run Ubuntu alongside&nbsp;it.</p>
+      <hr class="u-sv1">
+      <p class="u-no-margin--bottom"><strong>Do you want to upgrade?</strong> <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop">Follow our simple guide</a>
+    </div>
+    <div class="col-6 p-card">
+      <h2 class="p-card__title"><a href="/download/server">Ubuntu Server&nbsp;&rsaquo;</a></h2>
+      <p class="p-card__content">Whether you want to configure a simple file server or build a fifty thousand-node cloud, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
     </div>
   </div>
-  <div class="row u-equal-height u-no-margin--bottom">
-    <div class="col-6 p-card u-equal-height">
-      <div>
-        <h2 class="p-card__title"><a href="/download/server">Ubuntu Server&nbsp;&rsaquo;</a></h2>
-        <p class="p-card__content">Whether you want to configure a simple file server or build a fifty thousand-node cloud, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
-      </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <h2 class="p-card__title"><a href="https://multipass.run" class="p-link--external">Ubuntu for Windows/Mac</a></h2>
+      <p class="p-card__content">Create, control, and update local Ubuntu virtual machines using Multipass. Available for Windows, macOS, and Linux.</p>
     </div>
-    <div class="col-6 p-card u-equal-height">
-      <div>
-        <h2 class="p-card__title"><a href="/download/cloud">Ubuntu Cloud&nbsp;&rsaquo;</a></h2>
-        <p class="p-card__content">Ubuntu is the reference OS for OpenStack. Try Canonical&rsquo;s OpenStack on a single machine or start building a production cloud on a cluster &mdash; just add servers.</p>
-      </div>
+    <div class="col-6 p-card">
+      <h2 class="p-card__title"><a href="/download/cloud">Ubuntu Cloud&nbsp;&rsaquo;</a></h2>
+      <p class="p-card__content">Ubuntu is the reference OS for OpenStack. Try Canonical&rsquo;s OpenStack on a single machine or start building a production cloud on a cluster &mdash; just add servers.</p>
     </div>
   </div>
-  <div class="row u-equal-height u-no-margin--top u-no-margin--bottom">
-    <div class="col-6 p-card u-equal-height">
-      <div>
-        <h2 class="p-card__title"><a href="/download/ubuntu-flavours">Ubuntu flavours&nbsp;&rsaquo;</a></h2>
-        <p class="p-card__content">Ubuntu flavours offer a unique way to experience Ubuntu with different choices of default applications and settings, backed by the full Ubuntu archive for packages and updates.</p>
-      </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <h2 class="p-card__title"><a href="/download/ubuntu-flavours">Ubuntu flavours&nbsp;&rsaquo;</a></h2>
+      <p class="p-card__content">Ubuntu flavours offer a unique way to experience Ubuntu with different choices of default applications and settings, backed by the full Ubuntu archive for packages and updates.</p>
     </div>
-    <div class="col-6 p-card u-equal-height">
-      <div>
-        <h2 class="p-card__title"><a href="/download/core">Ubuntu for IoT&nbsp;&rsaquo;</a></h2>
-        <p class="p-card__content">Are you a developer who wants to try snappy Ubuntu Core? The new, transactionally updated Ubuntu for clouds and devices.</p>
-      </div>
+    <div class="col-6 p-card">
+      <h2 class="p-card__title"><a href="/download/core">Ubuntu for IoT&nbsp;&rsaquo;</a></h2>
+      <p class="p-card__content">Are you a developer who wants to try snappy Ubuntu Core? The new, transactionally updated Ubuntu for clouds and devices.</p>
     </div>
   </div>
 </div>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -5,46 +5,56 @@
 
 {% block content %}
 
-<section class="p-strip is-deep u-no-padding--bottom">
+<section class="p-strip is-deep">
   <div class="row">
     <div class="col-10">
       <h1>Download Ubuntu Server</h1>
     </div>
   </div>
-  <div class="row u-equal-height">
-    <div class="col-6 p-card--highlighted">
+  <div class="row">
+    <div class="col-12 p-card--highlighted">
       <h2>Ubuntu Server {{lts_release_with_point}} LTS</h2>
-      <div class="p-card__content">
-        <p>The long-term support version of Ubuntu Server, including the {{lts_openstack_version}} release of OpenStack and support guaranteed until {{lts_release_eol}} &mdash; 64-bit only.</p>
-        <p>This release uses our simplified installer, Subiquity. If you need complex functions such as encrypted filesystems, use <a href="/download/alternative-downloads#alternate-ubuntu-server-installer">the traditional installer</a>.</p>
-        <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ lts_release }} LTS release notes</a></p>
-        <p><a href="/download/server/thank-you?version={{ lts_release_with_point }}&amp;architecture=amd64" class="p-button--positive u-no-margin--bottom" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ lts_release_full }}', 'eventValue' : undefined });">Download</a></p>
+      <div class="u-equal-height p-divider">
+        <div class="col-8 p-divider__block">
+          <p class="p-card__content">The long-term support version of Ubuntu Server, including the {{lts_openstack_version}} release of OpenStack and support guaranteed until {{lts_release_eol}} &mdash; 64-bit only.</p>
+          <p class="p-card__content">This release uses our new installer, Subiquity. If you need support for options not implemented in Subiquity, such as encrypted filesystem support, the traditional installer can be found on the <a href="/download/alternative-downloads#alternate-ubuntu-server-installer">alternative downloads</a> page.</p>
+          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ lts_release }} LTS release notes</a></p>
+        </div>
+        <div class="col-4">
+          <p class="p-card__content"><a href="/download/server/thank-you?version={{ lts_release_with_point }}&amp;architecture=amd64" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ lts_release_full }}', 'eventValue' : undefined });">Download</a></p>
+          <p><small>For other versions of Ubuntu including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
+        </div>
       </div>
     </div>
-    <div class="col-6 p-card--highlighted">
+  </div>
+  <div class="row">
+    <div class="col-12 p-card--highlighted">
       <h2>Ubuntu Server {{ latest_release_with_point }}</h2>
-      <div class="p-card__content">
-        <p>The latest version of Ubuntu Server, including nine months of security and maintenance updates, until {{latest_release_eol}}.</p>
-        <p><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ latest_release }} release notes</a></p>
-        <p>
-          <a class="p-button--positive" href="/download/server/thank-you?version={{ latest_release_with_point }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">Download</a></p>
-        </p>
+      <div class="u-equal-height p-divider">
+        <div class="col-8 p-divider__block">
+          <p class="p-card__content">The latest version of Ubuntu Server, including nine months of security and maintenance updates, until {{latest_release_eol}}.</p>
+          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ latest_release }} release notes</a></p>
+        </div>
+        <div class="col-4">
+          <p class="p-card__content">
+            <a class="p-button--positive is-wide" href="/download/server/thank-you?version={{ latest_release_with_point }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">Download</a></p>
+            <p><small>For other versions of Ubuntu including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
+          </p>
+        </div>
       </div>
     </div>
   </div>
   <div class="row">
-    <div class="col-12">
-      <p><small>For other versions of Ubuntu including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-shallow is-bordered">
-  <div class="row">
-    <div class="col-12 p-card">
+    <div class="col-12 p-card--highlighted">
       <h3>Ubuntu Server on Windows or macOS with Multipass</h3>
-      <p>Quickly launch Ubuntu Server virtual machines with Multipass. Downloading and updating images is handled automatically. And you can use cloud-init to customise images before your first login.  Available for Linux, Windows, and macOS.</p>
-      <p><a href="https://multipass.run/install" class="p-button--positive u-no-margin--bottom"><span class="p-link--external">Download Multipass</span></a></p>
+      <div class="u-equal-height p-divider">
+        <div class="col-8 p-divider__block">
+          <p>Quickly launch Ubuntu Server virtual machines with Multipass. Downloading and updating images is handled automatically. And you can use cloud-init to customise images before your first login.  Available for Linux, Windows, and macOS.</p>
+        </div>
+        <div class="col-4">
+          <p><a href="https://multipass.run/install" class="p-button--positive is-wide"><span class="p-link--external">Download Multipass</span></a></p>
+        </div>
+      </div>
     </div>
   </div>
 </section>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -5,46 +5,49 @@
 
 {% block content %}
 
-<section class="p-strip is-deep is-bordered">
+<section class="p-strip is-deep u-no-padding--bottom">
   <div class="row">
     <div class="col-10">
       <h1>Download Ubuntu Server</h1>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12 p-card--highlighted">
+  <div class="row u-equal-height">
+    <div class="col-6 p-card--highlighted">
       <h2>Ubuntu Server {{lts_release_with_point}} LTS</h2>
-      <div class="u-equal-height p-divider">
-        <div class="col-8 p-divider__block">
-          <p class="p-card__content">The long-term support version of Ubuntu Server, including the {{lts_openstack_version}} release of OpenStack and support guaranteed until {{lts_release_eol}} &mdash; 64-bit only.</p>
-          <p class="p-card__content">This release uses our new installer, Subiquity. If you need support for options not implemented in Subiquity, such as encrypted filesystem support, the traditional installer can be found on the <a href="/download/alternative-downloads#alternate-ubuntu-server-installer">alternative downloads</a> page.</p>
-          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ lts_release }} LTS release notes</a></p>
-        </div>
-        <div class="col-4">
-          <p class="p-card__content"><a href="/download/server/thank-you?version={{ lts_release_with_point }}&amp;architecture=amd64" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ lts_release_full }}', 'eventValue' : undefined });">Download</a></p>
-          <p><small>For other versions of Ubuntu including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
-        </div>
+      <div class="p-card__content">
+        <p>The long-term support version of Ubuntu Server, including the {{lts_openstack_version}} release of OpenStack and support guaranteed until {{lts_release_eol}} &mdash; 64-bit only.</p>
+        <p>This release uses our simplified installer, Subiquity. If you need complex functions such as encrypted filesystems, use <a href="/download/alternative-downloads#alternate-ubuntu-server-installer">the traditional installer</a>.</p>
+        <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ lts_release }} LTS release notes</a></p>
+        <p><a href="/download/server/thank-you?version={{ lts_release_with_point }}&amp;architecture=amd64" class="p-button--positive u-no-margin--bottom" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ lts_release_full }}', 'eventValue' : undefined });">Download</a></p>
+      </div>
+    </div>
+    <div class="col-6 p-card--highlighted">
+      <h2>Ubuntu Server {{ latest_release_with_point }}</h2>
+      <div class="p-card__content">
+        <p>The latest version of Ubuntu Server, including nine months of security and maintenance updates, until {{latest_release_eol}}.</p>
+        <p><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ latest_release }} release notes</a></p>
+        <p>
+          <a class="p-button--positive" href="/download/server/thank-you?version={{ latest_release_with_point }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">Download</a></p>
+        </p>
       </div>
     </div>
   </div>
   <div class="row">
-  <div class="col-12 p-card--highlighted">
-      <h2>Ubuntu Server {{ latest_release_with_point }}</h2>
-      <div class="u-equal-height p-divider">
-        <div class="col-8 p-divider__block">
-          <p class="p-card__content">The latest version of Ubuntu Server, including nine months of security and maintenance updates, until {{latest_release_eol}}.</p>
-          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ latest_release }} release notes</a></p>
-        </div>
-        <div class="col-4">
-          <p class="p-card__content">
-            <a class="p-button--positive is-wide" href="/download/server/thank-you?version={{ latest_release_with_point }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ latest_release }}', 'eventValue' : undefined });">Download</a></p>
-            <p><small>For other versions of Ubuntu including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
-          </p>
-        </div>
-      </div>
+    <div class="col-12">
+      <p><small>For other versions of Ubuntu including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
     </div>
   </div>
- </section>
+</section>
+
+<section class="p-strip is-shallow is-bordered">
+  <div class="row">
+    <div class="col-12 p-card">
+      <h3>Ubuntu Server on Windows or macOS with Multipass</h3>
+      <p>Quickly launch Ubuntu Server virtual machines with Multipass. Downloading and updating images is handled automatically. And you can use cloud-init to customise images before your first login.  Available for Linux, Windows, and macOS.</p>
+      <p><a href="https://multipass.run/install" class="p-button--positive u-no-margin--bottom"><span class="p-link--external">Download Multipass</span></a></p>
+    </div>
+  </div>
+</section>
 
 <section class="p-strip--light is-shallow is-bordered">
   <div class="row">

--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -20,7 +20,7 @@
             <li class="p-list__item">Architectures and ISAs</li>
             <li class="p-list__item">Kernel selection &amp; lifecycle</li>
             <li class="p-list__item">
-              <a href="https://github.com/CanonicalLtd/multipass">Multipass&nbsp;&rsaquo;</a>
+              <a href="https://multipass.run">Multipass for easy Ubuntu VMs&nbsp;&rsaquo;</a>
             </li>
           </ul>
           <p><a class="p-button--positive p-button--small" href="/desktop/developers">Develop with Ubuntu</a></p>
@@ -86,7 +86,7 @@
               <a href="https://maas.io/">MAAS - fast server provisioning&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="https://github.com/CanonicalLtd/multipass">Multipass - Ubuntu on MacOS&nbsp;&rsaquo;</a>
+              <a href="https://multipass.run">Multipass - Ubuntu on MacOS&nbsp;&rsaquo;</a>
             </li>
           </ul>
         </div>
@@ -324,6 +324,12 @@
             </li>
             <li class="p-inline-list__item">
               <a href="https://snapcraft.io/">Snapcraft</a>
+            </li>
+            <li class="p-inline-list__item">
+              <a href="https://linuxcontainers.org/">LXD</a>
+            </li>
+            <li class="p-inline-list__item">
+              <a href="https://multipass.run/">Multipass</a>
             </li>
           </ul>
         </div>

--- a/templates/templates/_navigation-download-h.html
+++ b/templates/templates/_navigation-download-h.html
@@ -83,7 +83,7 @@
       <div class="col-3">
         <h4 class="p-muted-heading--small">Tutorials</h4>
         <p class="p-p--small">If you are already running Ubuntu - you can <a href='https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop'>upgrade</a> with the Software Updater</p>
-        <p class="p-p--small">Burn a DVD on <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-ubuntu'>Ubuntu</a>, <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-macos'>mac os</a>, or <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-windows'>Windows</a>. Create a bootable USB stick on <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu'>Ubuntu</a>, <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos'>mac os</a>, or <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows'>Windows</a></p>
+        <p class="p-p--small">Burn a DVD on <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-ubuntu'>Ubuntu</a>, <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-macos'>macOS</a>, or <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-windows'>Windows</a>. Create a bootable USB stick on <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu'>Ubuntu</a>, <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos'>mac os</a>, or <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows'>Windows</a></p>
         <p class="p-p--small">Installation guides for <a href='https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop'>Ubuntu Desktop</a> and <a href='https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server'>Ubuntu Server</a></p>
         <p class="p-p--small">You can learn how to <a href='https://tutorials.ubuntu.com/tutorial/try-ubuntu-before-you-install'>try Ubuntu before you install</a></p>
       </div>
@@ -93,7 +93,12 @@
       </div>
       <div class="col-3">
         <h4 class="p-muted-heading--small">Other ways to download</h4>
-        <p class="p-p--small">Ubuntu is available via <a href='/download/alternative-downloads#bittorrents'>BitTorrents</a> and via a minimal <a href='/download/alternative-downloads#network-installer'>network installer</a> that allows you to customise what is installed, such as additional languages. You can also find <a href='http://releases.ubuntu.com/'>older releases</a>.</p>
+        <ul class='p-text-list--small is-bordered p-list'>
+          <li class="p-list__item"><a href='/download/alternative-downloads#bittorrents'>BitTorrent</a></li>
+          <li class="p-list__item"><a href='/download/alternative-downloads#network-installer'>Minimal network installer</a></li>
+          <li class="p-list__item"><a href='http://releases.ubuntu.com/' class="p-link--external">Older releases</a></li>
+          <li class="p-list__item"><a href='https://multipass.run' class="p-link--external">Multipass for Ubuntu VMs</a></li>
+        </ul>
       </div>
       <div class="col-3">
         <h4 class="p-muted-heading--small">Ubuntu flavours</h4>


### PR DESCRIPTION
## Done
Promoted multipass.run in the following places:
- /download
- /download/server
- Developer menu
- Download menu

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /download and check it matched the [copy doc](https://docs.google.com/document/d/1egsCcmFiz8czeHsvwoB9Jz815Ij5Urtf7Ngrru6Zd4o/edit#heading=h.uabbhljvifoy)
- Go to /download/server and check it matched the [copy doc](https://docs.google.com/document/d/1FFQQUtzFGH88hA30qnZm-3pwVqcVl9UYyrNT4qQWrSM/edit#)
- Open the developer menu and check it matched the [copy doc](https://docs.google.com/document/d/1JzZPBydcdyV96Hu4xRpa7VDU_WREr6gb05bL7GlQaYY/edit)
- Open the download menu and check it matched the [copy doc](https://docs.google.com/document/d/11pX5gxOE6UWljIGRBZdwuCL1MHzs4pNgxJpK0mcIqdQ/edit)
