### PR TITLE
Remove promotional references to 14.04 (Trusty Tahr) as it is EOL

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -27,7 +27,6 @@
         <li class="p-list__item is-ticked"><a class="download-network p-link--external" href="http://cdimage.ubuntu.com/netboot/{{ latest_release }}/">Download the network installer for {{ latest_release }}</a></li>
         <li class="p-list__item is-ticked"><a class="download-network p-link--external" href="http://cdimage.ubuntu.com/netboot/{{ lts_release }}/">Download the network installer for {{ lts_release_full }}</a></li>
         <li class="p-list__item is-ticked"><a class="download-network p-link--external" href="http://cdimage.ubuntu.com/netboot/16.04/">Download the network installer for 16.04 LTS</a></li>
-        <li class="p-list__item is-ticked"><a class="download-network p-link--external" href="http://cdimage.ubuntu.com/netboot/14.04/">Download the network installer for 14.04 LTS</a></li>
       </ul>
     </div>
   </div>
@@ -63,15 +62,6 @@
         <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/{{ previous_lts_release }}/ubuntu-{{ previous_lts_release_with_point }}-desktop-i386.iso.torrent">Ubuntu {{ previous_lts_release_with_point }} Desktop (32-bit)</a></li>
         <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/{{ previous_lts_release }}/ubuntu-{{ previous_lts_release_with_point }}-server-amd64.iso.torrent">Ubuntu {{ previous_lts_release_with_point }} Server (64-bit)</a></li>
         <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/{{ previous_lts_release }}/ubuntu-{{ previous_lts_release_with_point }}-server-i386.iso.torrent">Ubuntu {{ previous_lts_release_with_point }} Server (32-bit)</a></li>
-      </ul>
-    </div>
-    <div class="col-3">
-      <h3 class="p-heading--four"><span>Ubuntu 14.04.6 LTS</span></h3>
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-amd64.iso.torrent">Ubuntu 14.04.6 Desktop (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-i386.iso.torrent">Ubuntu 14.04.6 Desktop (32-bit)</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.6-server-amd64.iso.torrent">Ubuntu 14.04.6 Server (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.6-server-i386.iso.torrent">Ubuntu 14.04.6 Server (32-bit)</a></li>
       </ul>
     </div>
   </div>

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -68,64 +68,6 @@
   </div>
 </div>
 
-<div class="p-strip">
-    <div class="row">
-      <div class="col-8">
-        <div>
-          <h2>Past ARM releases</h2>
-          <p>Find older versions of Ubuntu for specific ARM platforms.</p>
-        </div>
-      </div>
-    </div>
-
-    <div class="row u-equal-height">
-        <div class="col-6 p-card">
-          <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
-            <img src="{{ ASSET_SERVER_URL }}f38c9ed1-hpe_pri_grn_pos_rgb.svg" alt="" width="150" />
-          </div>
-          <h3 class="p-card__title">HP Moonshot</h3>
-          <ul class="p-list--divided">
-            <li class="p-list__item"><a class="p-link--external" href="http://ports.ubuntu.com/ubuntu-ports/dists/trusty-updates/main/installer-arm64/current/images/generic/netboot/xgene/">m400 ARMv8 netboot image (14.04 LTS)</a></li>
-            <li class="p-list__item"><a class="p-link--external" href="http://h20564.www2.hp.com/hpsc/doc/public/display?docId=c03933547">HP ProLiant Moonshot user guide</a></li>
-          </ul>
-          <p>HP Moonshot cartridges come factory installed</p>
-        </div>
-      <div class="col-6 p-card">
-        <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
-          <img src="{{ ASSET_SERVER_URL }}ca664713-partners-logo-apm.svg" alt="" width="150" />
-        </div>
-        <h3 class="p-card__title">Applied Micro X-Gene ARMv8</h3>
-        <ul class="p-list--divided">
-          <li class="p-list__item"><a class="p-link--external" href="http://ports.ubuntu.com/ubuntu-ports/dists/trusty/main/installer-arm64/current/images/generic/netboot/xgene/">14.04 LTS</a></li>
-          <li class="p-list__item"><a class="p-link--external" href="https://wiki.ubuntu.com/ARM/Server/Install/Mustang">Installation instructions for the Mustang platform</a></li>
-        </ul>
-      </div>
-    </div>
-
-    <div class="row u-equal-height">
-      <div class="col-6 p-card">
-        <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
-          <img src="{{ ASSET_SERVER_URL }}43b35b55-logo-cavium.png" alt="" width="150" />
-        </div>
-        <h3 class="p-card__title">Cavium Thunder 48 and 96 core ARMv8</h3>
-        <ul class="p-list--divided">
-          <li class="p-list__item"><a class="p-link--external" href="http://cavium.com/ThunderX_ARM_Processors.html">Cavium ThunderX product details </a></li>
-          <li class="p-list__item"><a class="p-link--external" href="http://www.cavium.com/ContactCavium.htm">14.04 LTS Tech Preview available directly from Cavium</a></li>
-        </ul>
-      </div>
-      <div class="col-6 p-card">
-        <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
-          <img src="{{ ASSET_SERVER_URL }}4fc650f0-Marvell_Logo.svg" alt="" width="150" />
-        </div>
-        <h3 class="p-card__title">Marvell Armada XP</h3>
-        <ul class="p-list--divided">
-          <li class="p-list__item"><a class="p-link--external" href="http://ports.ubuntu.com/ubuntu-ports/dists/precise-updates/main/installer-armhf/current/images/armadaxp/netboot">12.04 LTS</a></li>
-          <li class="p-list__item"><a class="p-link--external" href="https://wiki.ubuntu.com/ARM/Server/Install/ArmadaXP">Installation instructions for Armada XP-based systems</a></li>
-        </ul>
-      </div>
-    </div>
-  </div>
-
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_server_arm_guide" second_item="_download_enterprise_support" third_item="_download_helping_hands" %}
 
 {% endblock content %}

--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -1,7 +1,7 @@
 {% extends "livepatch/base_livepatch.html" %}
 
 {% block title %}Canonical Livepatch Service{% endblock %}
-{% block meta_description %}Automatic Linux kernel updates for Ubuntu 14.04, 16.04 and 18.04 LTS. Apply critical patches without rebooting and keep your systems secure and compliant.{% endblock %}
+{% block meta_description %}Automatic Linux kernel updates for Ubuntu 16.04 and 18.04 LTS. Apply critical patches without rebooting and keep your systems secure and compliant.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1Ofw9bQ4I40gy9hDIjuDMApz6sDK8qSdHI03-oY7xs-A/edit{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -231,7 +231,7 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <h3>Critical security fixes with zero downtime</h3>
-      <p>The Canonical Livepatch Service lets you apply kernel fixes in seconds, without restarting your Ubuntu 16.04 LTS and Ubuntu 14.04 LTS systems. Fewer reboots removes the operational burden associated planned downtimes for upgrades. It also means improved service availability and systems that are more compliant and secure.</p>
+      <p>The Canonical Livepatch Service lets you apply kernel fixes in seconds, without restarting your Ubuntu 18.04 LTS and Ubuntu 16.04 LTS systems. Fewer reboots removes the operational burden associated planned downtimes for upgrades. It also means improved service availability and systems that are more compliant and secure.</p>
       <p><a href="/livepatch">Learn more about Canonical&rsquo;s Livepatch Service&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 p-card">
@@ -249,7 +249,7 @@
     </div>
     <div class="col-6 p-card">
       <h3>Extend your Ubuntu 14.04 LTS security maintenance</h3>
-      <p>Following the end-of-life of Ubuntu 14.04 LTS in April 2017, Canonical began offering Ubuntu 14.04 ESM (Extended Security Maintenance), to Ubuntu Advantage customers to provide important security fixes for the kernel and essential user space packages. These updates are delivered via a secure, private archive exclusively available to Ubuntu Advantage customers.</p>
+      <p>Following the end-of-life of Ubuntu 14.04 LTS in April 2019, Canonical began offering Ubuntu 14.04 ESM (Extended Security Maintenance), to Ubuntu Advantage customers to provide important security fixes for the kernel and essential user space packages. These updates are delivered via a secure, private archive exclusively available to Ubuntu Advantage customers.</p>
       <p><a class="p-link--external" href="https://pages.ubuntu.com/01.Howtoupgradefrom12.04webinar_LPOn-demandwebinar.html?utm_source=insights&amp;utm_medium=blog&amp;utm_campaign=On-demand%20webinar%20--%20How%20to%20ensure%20the%20ongoing%20security%20compliance%20of%2012.04&amp;">Watch our security compliance webinar now</a></p>
     </div>
   </div>

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -231,7 +231,7 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <h3>Critical security fixes with zero downtime</h3>
-      <p>The Canonical Livepatch Service lets you apply kernel fixes in seconds, without restarting your Ubuntu 18.04 LTS and Ubuntu 16.04 LTS systems. Fewer reboots removes the operational burden associated planned downtimes for upgrades. It also means improved service availability and systems that are more compliant and secure.</p>
+      <p>The Canonical Livepatch Service lets you apply kernel fixes in seconds, without restarting your Ubuntu 18.04 LTS, 16.04 LTS or 14.04 ESM systems. Fewer reboots removes the operational burden associated planned downtimes for upgrades. It also means improved service availability and systems that are more compliant and secure.</p>
       <p><a href="/livepatch">Learn more about Canonical&rsquo;s Livepatch Service&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 p-card">


### PR DESCRIPTION
## Done

- Remove promotional references to 14.04 (Trusty Tahr) as it is EOL-

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
    - http://0.0.0.0:8001/security [copy doc](https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit)
    - http://0.0.0.0:8001/downloads/alternative-downloads [copy doc](https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit#heading=h.l92e027zu9m)
    - http://0.0.0.0:8001/livepatch [copy doc](https://docs.google.com/document/d/1Ofw9bQ4I40gy9hDIjuDMApz6sDK8qSdHI03-oY7xs-A/edit) - just from meta description
    - http://0.0.0.0:8001/download/server/arm [copy doc](https://docs.google.com/document/d/1whVU3DvB9j5k6Ed3UvLZCEN6BU-lZcow4ZefqKQqokg/edit#)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare the pages to the copy docs

## Issue / Card

Fixes #5081 

