### PR TITLE
Add ai/consulting page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -216,6 +216,8 @@ ai:
       path: /ai/features
     - title: Install
       path: /ai/install
+    - title: Consulting
+      path: /ai/consulting
 
     - title: Contact us
       path: /ai/contact-us

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -56,7 +56,7 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <h5 class="p-muted-heading u-sv3">Our consulting parteners</h5>
+      <h5 class="p-muted-heading u-sv3">Our consulting partners</h5>
       <ul class="row">
         <li class="col-2 mobile-col-2 tablet-col-2">
           <img
@@ -160,7 +160,7 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <h4">4 - Implementation</p>
+      <h4>4 - Implementation</p>
       <p>
         Complete the design process and begin
         training and testing your AI model until it reaches the desired accuracy

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -34,7 +34,6 @@
           href="https://assets.ubuntu.com/v1/223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf"
           >Read our consulting datasheet&nbsp;</a
         >
-        <!-- <a class="p-link" href="https://assets.ubuntu.com/v1/223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf">Read our whitepaper ›</a> -->
       </p>
     </div>
   </div>

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -5,7 +5,6 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/19Mx1zRJKqH2hz5kRF_oDsgyFUw67FgJvW4I_OGda-wk/edit#{% endblock meta_copydoc %}
 
 {% block content %}
-
 <section class="p-strip is-bordered">
   <div class="row">
     <div class="col-8">

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -62,7 +62,7 @@
   </div>
   <div class="row">
     <div class="col-8">
-      <p class="u-align--center">OUR CONSULTING PARTNERS</p>
+      <h5 class="u-align--center p-muted-heading">Our consulting parteners</h5>
       <ul id="cloud-partners" class="p-inline-images">
         <li class="p-inline-images__item">
           <img

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -1,0 +1,385 @@
+{% extends "ai/base_ai.html" %} 
+
+{% block title %}AI Consulting and Delivery{% endblock %} 
+{% block meta_description %}Consulting on artificial intelligence and machine learning for enterprise data analytics. Infrastructure for multi-cloud operations with Kubeflow, Tensorflow on Kubernetes.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/19Mx1zRJKqH2hz5kRF_oDsgyFUw67FgJvW4I_OGda-wk/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h1>
+        AI consulting and delivery
+      </h1>
+      <p class="p-heading--four">
+        Canonical and leading data scientists team up to consult on the full
+        enterprise AI stack.
+      </p>
+      <p>
+        Our data science consulting partners bring machine learning and deep
+        learning expertise. Canonical brings optimised infrastructure for
+        multi-cloud AI with Ubuntu, GPGPUs, Kubernetes and Kubeflow.
+      </p>
+      <p>
+        Assess data readiness, empower developers and accelerate your
+        processing. On-prem or on the cloud.
+      </p>
+      <p>
+        <a class="p-button--positive" href="/ai/contact-us?product=ai-index"
+          >Speak to the extperts</a
+        >
+        <a
+          class="p-link"
+          href="https://assets.ubuntu.com/v1/223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf"
+          >Read our consulting datasheet&nbsp;</a
+        >
+        <!-- <a class="p-link" href="https://assets.ubuntu.com/v1/223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf">Read our whitepaper ›</a> -->
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>Develop your data science capabilities</h2>
+      <p class="p-heading--four">
+        Stay focused and productive in a fast-moving landscape of code and data.
+      </p>
+      <p>
+        The complexity of AI/ML spans infrastructure, operations, machine
+        learning model development, model evolution, model deployment and
+        updates, compliance and security. To add to the challenge, the speed of
+        innovation in open source machine learning means that complexity is
+        compounding annually.
+      </p>
+      <p>
+        That’s why it pays off to bring Canonical and data scientists in early.
+        The right resources and experts accelerate delivery and keep your team
+        focused on your particular data streams and particular business
+        objectives.
+      </p>
+      <p>
+        Our five-step design sprint with your analytics and infrastructure teams
+        covers:
+      </p>
+      <!-- Change padding to variable -->
+      <ul class="p-list">
+        <li class="p-list__item">
+          <span style="font-weight: bold; padding-right:0.5rem;">1.</span>
+          Discovery - Goals, Challenges, Knowledge, Sprint Target
+        </li>
+        <li class="p-list__item">
+          <span style="font-weight: bold; padding-right:0.5rem;">2.</span>
+          Assessment - Data, Workflows, Gaps, Ideas, Users
+        </li>
+        <li class="p-list__item">
+          <span style="font-weight: bold; padding-right:0.5rem;">3.</span>
+          Design - Prototypes, Algorithms, Tests, Data
+        </li>
+        <li class="p-list__item">
+          <span style="font-weight: bold; padding-right:0.5rem;">4.</span>
+          Implementation - Models, Pipelines, Integrations
+        </li>
+        <li class="p-list__item">
+          <span style="font-weight: bold; padding-right:0.5rem;">5.</span>
+          Operation & Feedback - Deploy, Operate, Evaluate
+        </li>
+      </ul>
+      <p>
+        At the end of the engagement you will have a pattern for productive
+        developer workstations, cloud or on-prem machine learning
+        infrastructure, and AI applications delivering daily insights, powered
+        by your data.
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-muted-heading u-align--center">OUR CONSULTING PARTNERS</h2>
+      <ul id="cloud-partners" class="p-inline-images">
+        <li class="p-inline-images__item">
+          <a href="http://aws.amazon.com/"
+            ><img
+              class="p-inline-images__logo"
+              src="{{ ASSET_SERVER_URL }}7a581e36-Manceps_Logo_160.png"
+              style="max-width: 144px;"
+              width="144"
+              alt="Amazon Web Services"
+          /></a>
+        </li>
+        <li class="p-inline-images__item">
+          <a href="http://azure.microsoft.com/en-us/"
+            ><img
+              class="p-inline-images__logo"
+              src="{{ ASSET_SERVER_URL }}99d8f79e-deepsense.png"
+              style="max-width: 144px;"
+              width="144"
+              alt="Microsoft Azure"
+          /></a>
+        </li>
+        <li class="p-inline-images__item">
+          <a href="http://www.oracle.com/index.html"
+            ><img
+              class="p-inline-images__logo"
+              src="{{ ASSET_SERVER_URL }}b1f04506-Kubeflow-Logo-RGB.svg"
+              style="max-width: 144px;"
+              width="144"
+              alt="Oracle"
+          /></a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <h2>AI design sprint</h2>
+    <p class="p-heading--four">
+      Produce tangible results in one week with agile AI technologies and
+      methodologies
+    </p>
+    <p>
+      The core of our one week engagements centers on the AI design sprint - an
+      introduction our AI technologies and methodologies. We will develop a
+      proof of concept (PoC) that solves a real business challenge for your
+      organization. The results of this sprint will serve as a foundation for
+      your AI innovations.
+    </p>
+    <p>
+      The key outcomes that you can expect from this week are a baseline
+      architecture for iterative solution development – which includes a working
+      continuous integration pipeline – and a high level strategy that addresses
+      your AI transformation journey. Please note: this week typically relies on
+      having the right infrastructure in place to support the AI technology
+      stack.
+    </p>
+    <p class="p-heading--four">
+      The AI design process in more detail:
+    </p>
+  </div>
+  <div class="row">
+    <div class="col-6 u-hide--small u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}5d8aa78b-1+Discovery.svg" alt="" />
+    </div>
+    <div class="col-6">
+      <p class="p-heading--five">Day one</p>
+      <p>
+        <strong>Discovery:</strong> Following a consultative whiteboarding
+        session to set the stage, partner data scientists and data engineers
+        will explore your business requirements, expected outcomes, data
+        sources, potential opportunities and risks. The partner will discuss
+        machine learning use cases for your industry and explore the specific
+        business applications that can add the most value.
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p class="p-heading--five">Day two</p>
+      <p>
+        <strong>Assessment:</strong> Domain experts will provide initial
+        feedback based on the Discovery phase. They will report on the data and
+        make solution recommendations. They will discuss building a strategy
+        roadmap for the project based on your specific business case. Any
+        changes to your infrastructure should be highlighted during this step.
+      </p>
+    </div>
+    <div class="col-6 u-hide--small u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}0bb09a0a-2+Assessment.svg" alt="" />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6 u-hide--small u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}3f8aaa5f-3+Design.svg" alt="" />
+    </div>
+    <div class="col-6">
+      <p class="p-heading--five">Day three</p>
+      <p>
+        <strong>Design:</strong> Prototype new solutions and identify a
+        candidate solution that seems to be the best fit for the use case under
+        consideration. Data engineers should prepare the data. Data scientists
+        will discuss and select appropriate features and machine learning
+        algorithms. Machine Learning engineers will design, build and perform
+        preliminary tests on your prototype neural network. Time permitting,
+        start the iterative process of design and discovery on the data and the
+        neural network model.
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p class="p-heading--five">Day four</p>
+      <p>
+        <strong>Implementation:</strong> Complete the design process and begin
+        training and testing your AI model until it reaches the desired accuracy
+        threshold. Build a pipeline that will put your model into a suitable
+        environment for testing and feedback from additional stakeholders.
+        Domain experts will offer guidance on assessing machine learning
+        predictions and putting discovered insights into action.
+      </p>
+    </div>
+    <div class="col-6 u-hide--small u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}273fd9ee-4+Implementation.svg" alt="" />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6 u-hide--small u-vertically-center">
+      <img
+        src="{{ ASSET_SERVER_URL }}2021203f-5+Operation+and+feedback.svg"
+        alt=""
+      />
+    </div>
+    <div class="col-6">
+      <p class="p-heading--five">Day five</p>
+      <p>
+        <strong>Operation and Feedback:</strong> This may include UI
+        development, technical documentation, and hands-on knowledge transfer
+        between development and operations teams to ensure they can operate the
+        solution. It is important to discuss production deployment options – for
+        example, a dark launch or an integration with a prototypical business
+        application. During this step we’ll elicit feedback from key
+        stakeholders, covering the baseline architecture and model.
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <p>
+      The specific steps for each phase will be adjusted based on your
+      particular needs.
+    </p>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>Perfectly portable AI workloads</h2>
+      <p class="p-heading--four">
+        Open and pluggable machine learning workflows for multi-cloud AI, ML and
+        DL.
+      </p>
+      <p>
+        In the multi-cloud AI world, where AI practitioners leverage multiple
+        environments, portability requirements surface rather quickly. We
+        consider each environment to be different and in need of the ability to
+        define a repeatable machine learning stack.
+      </p>
+      <p>
+        The full AI/ML workflow starts with the developer workstation, for rapid
+        iteration of algorithms and analytic techniques. Training at scale takes
+        place on the rack or on GPGPU-accelerated instances on the cloud.
+        Resulting models are then delivered to the point of decision, whether
+        that’s on cloud or IoT at the edge.
+      </p>
+      <p>
+        Working with Canonical and all the leading clouds, Kubeflow on Ubuntu
+        provides infrastructure and operations that span that full range, and
+        seamless portability of AI workloads.
+      </p>
+      <!-- Update link -->
+      <a class="p-button--neutral" href="https://www.ubuntu.com/ai/features">
+        Explore Kubeflow
+      </a>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <h2>Train your infrastructure engineers</h2>
+    <p>
+      Get more detailed information in our
+      <a
+        href="https://assets.ubuntu.com/v1/223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf"
+        >consulting datasheet</a
+      >
+    </p>
+  </div>
+
+  {% include "shared/pricing/_kubernetes-consulting-add-ons.html" %}
+
+  <div class="row">
+    <p>
+      <a href="https://www.ubuntu.com/ai/contact-us?product=ai-index"
+        >Contact our experts</a
+      >
+      to get started with consulting, training or outsourced operations.
+    </p>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <p class="p-heading--three">
+      Learn more about AI/ML and Kubeflow
+    </p>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="row p-divider">
+        <div class="col-6 p-divider__block">
+          <h2>WEBINARS</h2>
+          <p>
+            A detailed look into the artificial intelligence and machine
+            learning. Learn about the AI landscape, how to deploy your first
+            model, and more.
+          </p>
+          <p>
+            <a href="https://blog.ubuntu.com/2018/10/02/ai-ml-model-ubuntu"
+              >How to build and deploy your first AI/ML model on Ubuntu</a
+            >
+          </p>
+          <p>
+            <a
+              href="https://blog.ubuntu.com/2018/07/26/ai-ml-ubuntu-everything-you-need-to-know"
+              >AI, ML, & Ubuntu: Everything you need to know.</a
+            >
+          </p>
+        </div>
+        <div class="col-6 p-divider__block">
+          <h2>ARTICLES</h2>
+          <p>
+            <a
+              href="https://www.cmswire.com/digital-experience/stop-waiting-on-the-ai-sidelines-heres-how-to-take-the-plunge/"
+              >Stop Waiting on the AI Sidelines: Here's How to Take the
+              Plunge</a
+            >
+            - cmswire.com
+          </p>
+          <p>
+            <a href="http://www.financederivative.com/getting-serious-about-ai/"
+              >Getting Serious About AI</a
+            >
+            - financederivative.com
+          </p>
+          <p>
+            <a
+              href="https://www.datacenterknowledge.com/industry-perspectives/kubernetes-and-ai-marriage-made-it-heaven"
+              >Kubernetes and AI: Marriage Made in IT Heaven</a
+            >
+            - datacenterknowledge.com
+          </p>
+          <p>
+            <a
+              href="https://www.comparethecloud.net/articles/automating-the-future-workplace/"
+              >Automating the Future of the Workplace</a
+            >
+            - comparethecloud.net
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% include "shared/contextual_footers/_contextual_footer.html" with
+first_item="_containers_juju" second_item="_cloud_lxd" third_item="_cloud_further_reading" %} 
+{% include "shared/forms/interactive/_kubeflow.html" with formid='3231' lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-managed'
+lpurl="https://pages.ubuntu.com/things-contact-us.html" %} 
+{% endblock content %}

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -160,7 +160,7 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <h4>4 - Implementation</p>
+      <h4>4 - Implementation</h4>
       <p>
         Complete the design process and begin
         training and testing your AI model until it reaches the desired accuracy

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -377,8 +377,7 @@
   </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html" with
-first_item="_containers_juju" second_item="_cloud_lxd" third_item="_cloud_further_reading" %} 
-{% include "shared/forms/interactive/_kubeflow.html" with formid='3231' lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-managed'
-lpurl="https://pages.ubuntu.com/things-contact-us.html" %} 
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_ubuntu_advantage" third_item="_cloud_further_reading" %}
+{% include "shared/forms/interactive/_kubeflow.html" with  formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-managed' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
 {% endblock content %}

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -97,20 +97,18 @@
       <p class="u-align--center">OUR CONSULTING PARTNERS</p>
       <ul id="cloud-partners" class="p-inline-images">
         <li class="p-inline-images__item">
-          <a href="https://www.manceps.com/"
-            ><img
-              class="p-inline-images__logo"
-              src="{{ ASSET_SERVER_URL }}7a581e36-Manceps_Logo_160.png"
-              alt="Manceps"
-          /></a>
+          <img
+            class="p-inline-images__logo"
+            src="{{ ASSET_SERVER_URL }}7a581e36-Manceps_Logo_160.png"
+            alt="Manceps"
+          />
         </li>
         <li class="p-inline-images__item">
-          <a href="https://deepsense.ai/"
-            ><img
-              class="p-inline-images__logo"
-              src="{{ ASSET_SERVER_URL }}99d8f79e-deepsense.png"
-              alt="Deepsense AI"
-          /></a>
+          <img
+            class="p-inline-images__logo"
+            src="{{ ASSET_SERVER_URL }}99d8f79e-deepsense.png"
+            alt="Deepsense AI"
+          />
         </li>
       </ul>
     </div>

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -24,7 +24,7 @@
         >
         <a
           class="p-link--external"
-          href="https://assets.ubuntu.com/v1/223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf"
+          href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf"
           >Read our consulting datasheet</a
         >
       </p>
@@ -47,13 +47,7 @@
         compounding annually.
       </p>
       <p>
-        That’s why it pays off to bring Canonical and data scientists in early.
-        The right resources and experts accelerate delivery and keep your team
-        focused on your particular data streams and particular business
-        objectives.
-      </p>
-      <p>
-        Together, we help deliver a five-day/five-step AI design sprint with your analytics and infrastructure teams. At the end of the engagement you will have a pattern for productive developer workstations, a machine learning infrastructure (in the cloud or on-premises), and AI applications delivering daily insights, powered by your data.
+        That’s why it pays off to bring Canonical and data scientists in early. The right resources and experts accelerate delivery and keep your team focused on your particular data streams and particular business objectives.  Together, we help deliver a five-day/five-step AI design sprint with your analytics and infrastructure teams. At the end of the engagement you will have a pattern for productive developer workstations, a machine learning infrastructure (in the cloud or on-premises), and AI applications delivering daily insights, powered by your data.
       </p>
       <p class="u-sv3">
         With our structured program, we can approach any situation and provide the infrastructure and capabilities that your business needs. Proven best practices mean that we can take the guesswork and experimentation out of your AI adoption, and fast-track you to value without breaking your budget.
@@ -61,19 +55,17 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-12 u-align--center">
-      <h5 class="u-align--center p-muted-heading">Our consulting parteners</h5>
-      <ul id="cloud-partners" class="p-inline-images">
-        <li class="p-inline-images__item">
+    <div class="col-12">
+      <h5 class="p-muted-heading u-sv3">Our consulting parteners</h5>
+      <ul class="row">
+        <li class="col-2 mobile-col-2 tablet-col-2">
           <img
-            class="p-inline-images__logo"
-            src="{{ ASSET_SERVER_URL }}7a581e36-Manceps_Logo_160.png"
+            src="{{ ASSET_SERVER_URL }}e9e4d429-Manceps.png"
             alt="Manceps"
           />
         </li>
-        <li class="p-inline-images__item">
+        <li class="col-2 mobile-col-2 tablet-col-2">
           <img
-            class="p-inline-images__logo"
             src="{{ ASSET_SERVER_URL }}99d8f79e-deepsense.png"
             alt="Deepsense AI"
           />
@@ -110,11 +102,11 @@
     </h3>
   </div>
   <div class="row">
-    <div class="col-6 u-hide--small u-align-center">
+    <div class="col-6 u-hide--small u-align--center">
       <img src="{{ ASSET_SERVER_URL }}5d8aa78b-1+Discovery.svg" alt="" width="335px"/>
     </div>
     <div class="col-6">
-      <p class="p-heading--four">1 - Discovery</p>
+      <h4>1 - Discovery</h4>
       <p>
         Following a consultative whiteboarding session to set the stage, partner data scientists and data engineers
         will explore your business requirements, expected outcomes, data
@@ -129,7 +121,7 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <p class="p-heading--four">2 - Assesment</p>
+      <h4>2 - Assessment</h4>
       <p>
         Domain experts will provide initial
         feedback based on the Discovery phase. They will report on the data and
@@ -150,7 +142,7 @@
       <img src="{{ ASSET_SERVER_URL }}3f8aaa5f-3+Design.svg" alt="" width="335px"/>
     </div>
     <div class="col-6">
-      <p class="p-heading--four">3 - Design</p>
+      <h4>3 - Design</h4>
       <p>
         Prototype new solutions and identify a
         candidate solution that seems to be the best fit for the use case under
@@ -168,7 +160,7 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <p class="p-heading--four">4 - Implementation</p>
+      <h4">4 - Implementation</p>
       <p>
         Complete the design process and begin
         training and testing your AI model until it reaches the desired accuracy
@@ -194,7 +186,7 @@
       />
     </div>
     <div class="col-6">
-      <p class="p-heading--four">5 - Operation and Feedback</p>
+      <h4>5 - Operation and Feedback</h4>
       <p>
         This may include UI
         development, technical documentation, and hands-on knowledge transfer
@@ -221,10 +213,10 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <h2>Perfectly portable AI workloads</h2>
-      <p class="p-heading--four u-sv3">
+      <h4 class="u-sv3">
         Open and pluggable machine learning workflows for multi-cloud AI, ML and
         DL.
-      </p>
+      </h4>
       <p>
         In the multi-cloud AI world, where AI practitioners leverage multiple
         environments, portability requirements surface rather quickly. We
@@ -243,12 +235,12 @@
         provides infrastructure and operations that span that full range, and
         seamless portability of AI workloads.
       </p>
-      <a class="p-button--neutral" href="https://www.ubuntu.com/ai/features">
+      <a class="p-button--neutral" href="/ai/features">
         Explore Kubeflow
       </a>
     </div>
     <div class="col-4 prefix-1 u-vertically-center u-align--center u-hide--small">
-      <img src="{{ ASSET_SERVER_URL }}da5a7c9e-Kubeflow-Logo.svg" alt="" width="275px">
+      <img src="{{ ASSET_SERVER_URL }}da5a7c9e-Kubeflow-Logo.svg" alt="" width="180px">
     </div>
   </div>
 </section>
@@ -260,7 +252,7 @@
       Get more detailed information in our
       <a
         class="p-link--external"
-        href="https://assets.ubuntu.com/v1/223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf"
+        href="{{ ASSET_SERVER_URL }}223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf"
         >consulting datasheet</a
       >
     </p>
@@ -270,7 +262,7 @@
 
   <div class="row">
     <p>
-      <a href="https://www.ubuntu.com/ai/contact-us?product=ai-index"
+      <a href="/ai/contact-us?product=ai-index"
         >Contact our experts</a
       >
       to get started with consulting, training or outsourced operations.
@@ -278,7 +270,7 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section class="p-strip--light is-bordered">
   <div class="row">
     <h3>
       Learn more about AI/ML and Kubeflow
@@ -290,7 +282,7 @@
         <div class="col-6 p-divider__block">
             <div class="p-heading-icon--muted">
               <div class="p-heading-icon__header">
-                <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/26797d10-newsfeed-stripvideo-icon.svg" width="32" alt="">
+                <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" width="32" alt="">
                 <h4 class="p-heading-icon__title">Webinars</h4>
               </div>
             </div>
@@ -315,7 +307,7 @@
         <div class="col-6 p-divider__block">
           <div class="p-heading-icon--muted">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/cd7a3a3c-white-paper-icon.svg" width="32" alt="">
+              <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" width="32" alt="">
               <h4 class="p-heading-icon__title">Articles</h4>
             </div>
           </div>
@@ -327,7 +319,7 @@
             >
           </p>
           <p>
-            <a href="http://www.financederivative.com/getting-serious-about-ai/"
+            <a class="p-link--external" href="http://www.financederivative.com/getting-serious-about-ai/"
               >Getting Serious About AI</a
             >
           </p>

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -235,7 +235,7 @@
         provides infrastructure and operations that span that full range, and
         seamless portability of AI workloads.
       </p>
-      <a class="p-button--neutral" href="/ai/features">
+      <a class="p-button--neutral" href="/engage/deploy-ai-ml-model?utm_campaign=FY19_Cloud_K8_WBN_AIWebinar2">
         Explore Kubeflow
       </a>
     </div>

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -11,7 +11,7 @@
       <h1>
         AI consulting and delivery
       </h1>
-      <p class="p-heading--four">
+      <p class="p-heading--four u-sv3">
         Canonical and leading data scientists team up to consult on the full
         enterprise AI stack.
       </p>
@@ -26,12 +26,12 @@
       </p>
       <p>
         <a class="p-button--positive" href="/ai/contact-us?product=ai-index"
-          >Speak to the extperts</a
+          >Speak to the experts</a
         >
         <a
-          class="p-link"
+          class="p-link--external"
           href="https://assets.ubuntu.com/v1/223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf"
-          >Read our consulting datasheet&nbsp;</a
+          >Read our consulting datasheet</a
         >
       </p>
     </div>
@@ -42,7 +42,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Develop your data science capabilities</h2>
-      <p class="p-heading--four">
+      <p class="p-heading--four u-sv3">
         Stay focused and productive in a fast-moving landscape of code and data.
       </p>
       <p>
@@ -62,7 +62,6 @@
         Our five-step design sprint with your analytics and infrastructure teams
         covers:
       </p>
-      <!-- Change padding to variable -->
       <ul class="p-list">
         <li class="p-list__item">
           <span style="font-weight: bold; padding-right:0.5rem;">1.</span>
@@ -93,41 +92,24 @@
       </p>
     </div>
   </div>
-</section>
-
-<section class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
-      <h2 class="p-muted-heading u-align--center">OUR CONSULTING PARTNERS</h2>
+      <p class="u-align--center">OUR CONSULTING PARTNERS</p>
       <ul id="cloud-partners" class="p-inline-images">
         <li class="p-inline-images__item">
-          <a href="http://aws.amazon.com/"
+          <a href="https://www.manceps.com/"
             ><img
               class="p-inline-images__logo"
               src="{{ ASSET_SERVER_URL }}7a581e36-Manceps_Logo_160.png"
-              style="max-width: 144px;"
-              width="144"
-              alt="Amazon Web Services"
+              alt="Manceps"
           /></a>
         </li>
         <li class="p-inline-images__item">
-          <a href="http://azure.microsoft.com/en-us/"
+          <a href="https://deepsense.ai/"
             ><img
               class="p-inline-images__logo"
               src="{{ ASSET_SERVER_URL }}99d8f79e-deepsense.png"
-              style="max-width: 144px;"
-              width="144"
-              alt="Microsoft Azure"
-          /></a>
-        </li>
-        <li class="p-inline-images__item">
-          <a href="http://www.oracle.com/index.html"
-            ><img
-              class="p-inline-images__logo"
-              src="{{ ASSET_SERVER_URL }}b1f04506-Kubeflow-Logo-RGB.svg"
-              style="max-width: 144px;"
-              width="144"
-              alt="Oracle"
+              alt="Deepsense AI"
           /></a>
         </li>
       </ul>
@@ -135,10 +117,10 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip is-bordered">
   <div class="row">
     <h2>AI design sprint</h2>
-    <p class="p-heading--four">
+    <p class="p-heading--four u-sv3">
       Produce tangible results in one week with agile AI technologies and
       methodologies
     </p>
@@ -149,7 +131,7 @@
       organization. The results of this sprint will serve as a foundation for
       your AI innovations.
     </p>
-    <p>
+    <p class="u-sv3">
       The key outcomes that you can expect from this week are a baseline
       architecture for iterative solution development – which includes a working
       continuous integration pipeline – and a high level strategy that addresses
@@ -157,19 +139,18 @@
       having the right infrastructure in place to support the AI technology
       stack.
     </p>
-    <p class="p-heading--four">
-      The AI design process in more detail:
+    <p class="p-heading--three u-sv3">
+      The AI design process in more detail
     </p>
   </div>
   <div class="row">
-    <div class="col-6 u-hide--small u-vertically-center">
-      <img src="{{ ASSET_SERVER_URL }}5d8aa78b-1+Discovery.svg" alt="" />
+    <div class="col-6 u-hide--small u-align-center">
+      <img src="{{ ASSET_SERVER_URL }}5d8aa78b-1+Discovery.svg" alt="" width="335px"/>
     </div>
     <div class="col-6">
-      <p class="p-heading--five">Day one</p>
+      <p class="p-heading--four">1. Discovery</p>
       <p>
-        <strong>Discovery:</strong> Following a consultative whiteboarding
-        session to set the stage, partner data scientists and data engineers
+        Following a consultative whiteboarding session to set the stage, partner data scientists and data engineers
         will explore your business requirements, expected outcomes, data
         sources, potential opportunities and risks. The partner will discuss
         machine learning use cases for your industry and explore the specific
@@ -178,28 +159,34 @@
     </div>
   </div>
   <div class="row">
+    <hr class="p-separator"/>
+  </div>
+  <div class="row">
     <div class="col-6">
-      <p class="p-heading--five">Day two</p>
+      <p class="p-heading--four">2. Assesment</p>
       <p>
-        <strong>Assessment:</strong> Domain experts will provide initial
+        Domain experts will provide initial
         feedback based on the Discovery phase. They will report on the data and
         make solution recommendations. They will discuss building a strategy
         roadmap for the project based on your specific business case. Any
         changes to your infrastructure should be highlighted during this step.
       </p>
     </div>
-    <div class="col-6 u-hide--small u-vertically-center">
-      <img src="{{ ASSET_SERVER_URL }}0bb09a0a-2+Assessment.svg" alt="" />
+    <div class="col-6 u-hide--small u-align-center">
+      <img src="{{ ASSET_SERVER_URL }}0bb09a0a-2+Assessment.svg" alt="" width="335px"/>
     </div>
   </div>
   <div class="row">
-    <div class="col-6 u-hide--small u-vertically-center">
-      <img src="{{ ASSET_SERVER_URL }}3f8aaa5f-3+Design.svg" alt="" />
+    <hr class="p-separator"/>
+  </div>
+  <div class="row">
+    <div class="col-6 u-hide--small u-align-center">
+      <img src="{{ ASSET_SERVER_URL }}3f8aaa5f-3+Design.svg" alt="" width="335px"/>
     </div>
     <div class="col-6">
-      <p class="p-heading--five">Day three</p>
+      <p class="p-heading--four">3. Design</p>
       <p>
-        <strong>Design:</strong> Prototype new solutions and identify a
+        Prototype new solutions and identify a
         candidate solution that seems to be the best fit for the use case under
         consideration. Data engineers should prepare the data. Data scientists
         will discuss and select appropriate features and machine learning
@@ -211,10 +198,13 @@
     </div>
   </div>
   <div class="row">
+    <hr class="p-separator"/>
+  </div>
+  <div class="row">
     <div class="col-6">
-      <p class="p-heading--five">Day four</p>
+      <p class="p-heading--four">4. Implementation</p>
       <p>
-        <strong>Implementation:</strong> Complete the design process and begin
+        Complete the design process and begin
         training and testing your AI model until it reaches the desired accuracy
         threshold. Build a pipeline that will put your model into a suitable
         environment for testing and feedback from additional stakeholders.
@@ -222,21 +212,25 @@
         predictions and putting discovered insights into action.
       </p>
     </div>
-    <div class="col-6 u-hide--small u-vertically-center">
-      <img src="{{ ASSET_SERVER_URL }}273fd9ee-4+Implementation.svg" alt="" />
+    <div class="col-6 u-hide--small u-align-center">
+      <img src="{{ ASSET_SERVER_URL }}273fd9ee-4+Implementation.svg" alt="" width="335px"/>
     </div>
   </div>
   <div class="row">
-    <div class="col-6 u-hide--small u-vertically-center">
+    <hr class="p-separator"/>
+  </div>
+  <div class="row">
+    <div class="col-6 u-hide--small u-align-center">
       <img
         src="{{ ASSET_SERVER_URL }}2021203f-5+Operation+and+feedback.svg"
-        alt=""
+        alt="" 
+        width="335px"
       />
     </div>
     <div class="col-6">
-      <p class="p-heading--five">Day five</p>
+      <p class="p-heading--four">5. Operation and Feedback</p>
       <p>
-        <strong>Operation and Feedback:</strong> This may include UI
+        This may include UI
         development, technical documentation, and hands-on knowledge transfer
         between development and operations teams to ensure they can operate the
         solution. It is important to discuss production deployment options – for
@@ -247,6 +241,9 @@
     </div>
   </div>
   <div class="row">
+    <hr class="p-separator"/>
+  </div>
+  <div class="row">
     <p>
       The specific steps for each phase will be adjusted based on your
       particular needs.
@@ -254,11 +251,11 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
       <h2>Perfectly portable AI workloads</h2>
-      <p class="p-heading--four">
+      <p class="p-heading--four u-sv3">
         Open and pluggable machine learning workflows for multi-cloud AI, ML and
         DL.
       </p>
@@ -288,12 +285,13 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip is-bordered">
   <div class="row">
     <h2>Train your infrastructure engineers</h2>
     <p>
       Get more detailed information in our
       <a
+        class="p-link--external"
         href="https://assets.ubuntu.com/v1/223eab1a-canonical-kubernetes-enterprise-2018-25-07.pdf"
         >consulting datasheet</a
       >
@@ -314,61 +312,70 @@
 
 <section class="p-strip is-bordered">
   <div class="row">
-    <p class="p-heading--three">
+    <h3>
       Learn more about AI/ML and Kubeflow
-    </p>
-  </div>
+    </h3>
+  </div>  
   <div class="row">
     <div class="col-12">
       <div class="row p-divider">
         <div class="col-6 p-divider__block">
-          <h2>WEBINARS</h2>
+            <div class="p-heading-icon--muted">
+              <div class="p-heading-icon__header">
+                <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/26797d10-newsfeed-stripvideo-icon.svg" width="32" alt="">
+                <h4 class="p-heading-icon__title">Webinars</h4>
+              </div>
+            </div>
           <p>
             A detailed look into the artificial intelligence and machine
             learning. Learn about the AI landscape, how to deploy your first
             model, and more.
           </p>
           <p>
-            <a href="https://blog.ubuntu.com/2018/10/02/ai-ml-model-ubuntu"
-              >How to build and deploy your first AI/ML model on Ubuntu</a
-            >
-          </p>
-          <p>
             <a
+              class="p-link--external"
               href="https://blog.ubuntu.com/2018/07/26/ai-ml-ubuntu-everything-you-need-to-know"
               >AI, ML, & Ubuntu: Everything you need to know.</a
             >
           </p>
+          <p>
+            <a class="p-link--external" href="https://blog.ubuntu.com/2018/10/02/ai-ml-model-ubuntu"
+              >How to build and deploy your first AI/ML model on Ubuntu</a
+            >
+          </p>
         </div>
         <div class="col-6 p-divider__block">
-          <h2>ARTICLES</h2>
+          <div class="p-heading-icon--muted">
+            <div class="p-heading-icon__header">
+              <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/cd7a3a3c-white-paper-icon.svg" width="32" alt="">
+              <h4 class="p-heading-icon__title">Articles</h4>
+            </div>
+          </div>
           <p>
             <a
+              class="p-link--external"
               href="https://www.cmswire.com/digital-experience/stop-waiting-on-the-ai-sidelines-heres-how-to-take-the-plunge/"
-              >Stop Waiting on the AI Sidelines: Here's How to Take the
-              Plunge</a
+              >Here's How to Take the Plunge</a
             >
-            - cmswire.com
           </p>
           <p>
             <a href="http://www.financederivative.com/getting-serious-about-ai/"
               >Getting Serious About AI</a
             >
-            - financederivative.com
           </p>
           <p>
             <a
+              class="p-link--external"
               href="https://www.datacenterknowledge.com/industry-perspectives/kubernetes-and-ai-marriage-made-it-heaven"
               >Kubernetes and AI: Marriage Made in IT Heaven</a
             >
-            - datacenterknowledge.com
           </p>
           <p>
             <a
+              class="p-link--external"
               href="https://www.comparethecloud.net/articles/automating-the-future-workplace/"
               >Automating the Future of the Workplace</a
             >
-            - comparethecloud.net
           </p>
         </div>
       </div>

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -11,10 +11,10 @@
       <h1>
         AI consulting and delivery
       </h1>
-      <p class="p-heading--four u-sv3">
+      <h4 class="u-sv3">
         Canonical and leading data scientists team up to consult on the full
         enterprise AI stack.
-      </p>
+      </h4>
       <p>
         Our data science consulting partners bring machine learning and deep learning expertise to the AI mix and Canonical delivers  optimised infrastructure for multi-cloud AI with Ubuntu, GPGPUs, Kubernetes and Kubeflow. Assess data readiness, empower developers and accelerate your processing on-premises or in the cloud.
       </p>
@@ -36,9 +36,9 @@
   <div class="row">
     <div class="col-8">
       <h2>Develop your data science capabilities</h2>
-      <p class="p-heading--four u-sv3">
+      <h4 class="u-sv3">
         Stay focused and productive in a fast-moving landscape of code and data.
-      </p>
+      </h4>
       <p>
         The complexity of AI/ML spans infrastructure, operations, machine
         learning model development, model evolution, model deployment and
@@ -61,7 +61,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-8">
+    <div class="col-12 u-align--center">
       <h5 class="u-align--center p-muted-heading">Our consulting parteners</h5>
       <ul id="cloud-partners" class="p-inline-images">
         <li class="p-inline-images__item">
@@ -86,10 +86,10 @@
 <section class="p-strip is-bordered">
   <div class="row">
     <h2>AI design sprint</h2>
-    <p class="p-heading--four u-sv3">
+    <h4 class="u-sv3">
       Produce tangible results in one week with agile AI technologies and
       methodologies
-    </p>
+    </h4>
     <p>
       The core of our one week engagements centers on the AI design sprint - an
       introduction our AI technologies and methodologies. We will develop a
@@ -105,9 +105,9 @@
       having the right infrastructure in place to support the AI technology
       stack.
     </p>
-    <p class="p-heading--three u-sv3">
+    <h3 class="u-sv3">
       The AI design process in more detail
-    </p>
+    </h3>
   </div>
   <div class="row">
     <div class="col-6 u-hide--small u-align-center">
@@ -138,7 +138,7 @@
         changes to your infrastructure should be highlighted during this step.
       </p>
     </div>
-    <div class="col-6 u-hide--small u-align-center">
+    <div class="col-6 u-hide--small u-align--center">
       <img src="{{ ASSET_SERVER_URL }}0bb09a0a-2+Assessment.svg" alt="" width="335px"/>
     </div>
   </div>
@@ -146,7 +146,7 @@
     <hr class="p-separator"/>
   </div>
   <div class="row">
-    <div class="col-6 u-hide--small u-align-center">
+    <div class="col-6 u-hide--small u-align--center">
       <img src="{{ ASSET_SERVER_URL }}3f8aaa5f-3+Design.svg" alt="" width="335px"/>
     </div>
     <div class="col-6">
@@ -178,7 +178,7 @@
         predictions and putting discovered insights into action.
       </p>
     </div>
-    <div class="col-6 u-hide--small u-align-center">
+    <div class="col-6 u-hide--small u-align--center">
       <img src="{{ ASSET_SERVER_URL }}273fd9ee-4+Implementation.svg" alt="" width="335px"/>
     </div>
   </div>
@@ -186,7 +186,7 @@
     <hr class="p-separator"/>
   </div>
   <div class="row">
-    <div class="col-6 u-hide--small u-align-center">
+    <div class="col-6 u-hide--small u-align--center">
       <img
         src="{{ ASSET_SERVER_URL }}2021203f-5+Operation+and+feedback.svg"
         alt="" 

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -16,13 +16,7 @@
         enterprise AI stack.
       </p>
       <p>
-        Our data science consulting partners bring machine learning and deep
-        learning expertise. Canonical brings optimised infrastructure for
-        multi-cloud AI with Ubuntu, GPGPUs, Kubernetes and Kubeflow.
-      </p>
-      <p>
-        Assess data readiness, empower developers and accelerate your
-        processing. On-prem or on the cloud.
+        Our data science consulting partners bring machine learning and deep learning expertise to the AI mix and Canonical delivers  optimised infrastructure for multi-cloud AI with Ubuntu, GPGPUs, Kubernetes and Kubeflow. Assess data readiness, empower developers and accelerate your processing on-premises or in the cloud.
       </p>
       <p>
         <a class="p-button--positive" href="/ai/contact-us?product=ai-index"
@@ -59,41 +53,15 @@
         objectives.
       </p>
       <p>
-        Our five-step design sprint with your analytics and infrastructure teams
-        covers:
+        Together, we help deliver a five-day/five-step AI design sprint with your analytics and infrastructure teams. At the end of the engagement you will have a pattern for productive developer workstations, a machine learning infrastructure (in the cloud or on-premises), and AI applications delivering daily insights, powered by your data.
       </p>
-      <ul class="p-list">
-        <li class="p-list__item">
-          <span style="font-weight: bold; padding-right:0.5rem;">1.</span>
-          Discovery - Goals, Challenges, Knowledge, Sprint Target
-        </li>
-        <li class="p-list__item">
-          <span style="font-weight: bold; padding-right:0.5rem;">2.</span>
-          Assessment - Data, Workflows, Gaps, Ideas, Users
-        </li>
-        <li class="p-list__item">
-          <span style="font-weight: bold; padding-right:0.5rem;">3.</span>
-          Design - Prototypes, Algorithms, Tests, Data
-        </li>
-        <li class="p-list__item">
-          <span style="font-weight: bold; padding-right:0.5rem;">4.</span>
-          Implementation - Models, Pipelines, Integrations
-        </li>
-        <li class="p-list__item">
-          <span style="font-weight: bold; padding-right:0.5rem;">5.</span>
-          Operation & Feedback - Deploy, Operate, Evaluate
-        </li>
-      </ul>
-      <p>
-        At the end of the engagement you will have a pattern for productive
-        developer workstations, cloud or on-prem machine learning
-        infrastructure, and AI applications delivering daily insights, powered
-        by your data.
+      <p class="u-sv3">
+        With our structured program, we can approach any situation and provide the infrastructure and capabilities that your business needs. Proven best practices mean that we can take the guesswork and experimentation out of your AI adoption, and fast-track you to value without breaking your budget.
       </p>
     </div>
   </div>
   <div class="row">
-    <div class="col-12">
+    <div class="col-8">
       <p class="u-align--center">OUR CONSULTING PARTNERS</p>
       <ul id="cloud-partners" class="p-inline-images">
         <li class="p-inline-images__item">
@@ -146,7 +114,7 @@
       <img src="{{ ASSET_SERVER_URL }}5d8aa78b-1+Discovery.svg" alt="" width="335px"/>
     </div>
     <div class="col-6">
-      <p class="p-heading--four">1. Discovery</p>
+      <p class="p-heading--four">1 - Discovery</p>
       <p>
         Following a consultative whiteboarding session to set the stage, partner data scientists and data engineers
         will explore your business requirements, expected outcomes, data
@@ -161,7 +129,7 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <p class="p-heading--four">2. Assesment</p>
+      <p class="p-heading--four">2 - Assesment</p>
       <p>
         Domain experts will provide initial
         feedback based on the Discovery phase. They will report on the data and
@@ -182,7 +150,7 @@
       <img src="{{ ASSET_SERVER_URL }}3f8aaa5f-3+Design.svg" alt="" width="335px"/>
     </div>
     <div class="col-6">
-      <p class="p-heading--four">3. Design</p>
+      <p class="p-heading--four">3 - Design</p>
       <p>
         Prototype new solutions and identify a
         candidate solution that seems to be the best fit for the use case under
@@ -200,7 +168,7 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <p class="p-heading--four">4. Implementation</p>
+      <p class="p-heading--four">4 - Implementation</p>
       <p>
         Complete the design process and begin
         training and testing your AI model until it reaches the desired accuracy
@@ -226,7 +194,7 @@
       />
     </div>
     <div class="col-6">
-      <p class="p-heading--four">5. Operation and Feedback</p>
+      <p class="p-heading--four">5 - Operation and Feedback</p>
       <p>
         This may include UI
         development, technical documentation, and hands-on knowledge transfer
@@ -250,7 +218,7 @@
 </section>
 
 <section class="p-strip--light is-bordered">
-  <div class="row">
+  <div class="row u-equal-height">
     <div class="col-8">
       <h2>Perfectly portable AI workloads</h2>
       <p class="p-heading--four u-sv3">
@@ -275,10 +243,12 @@
         provides infrastructure and operations that span that full range, and
         seamless portability of AI workloads.
       </p>
-      <!-- Update link -->
       <a class="p-button--neutral" href="https://www.ubuntu.com/ai/features">
         Explore Kubeflow
       </a>
+    </div>
+    <div class="col-4 prefix-1 u-vertically-center u-align--center u-hide--small">
+      <img src="{{ ASSET_SERVER_URL }}da5a7c9e-Kubeflow-Logo.svg" alt="" width="275px">
     </div>
   </div>
 </section>

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -19,7 +19,7 @@
         Our data science consulting partners bring machine learning and deep learning expertise to the AI mix and Canonical delivers  optimised infrastructure for multi-cloud AI with Ubuntu, GPGPUs, Kubernetes and Kubeflow. Assess data readiness, empower developers and accelerate your processing on-premises or in the cloud.
       </p>
       <p>
-        <a class="p-button--positive" href="/ai/contact-us?product=ai-index"
+        <a class="p-button--positive js-invoke-modal" href="/ai/contact-us?product=ai-index"
           >Speak to the experts</a
         >
         <a
@@ -260,14 +260,6 @@
 
   {% include "shared/pricing/_kubernetes-consulting-add-ons.html" %}
 
-  <div class="row">
-    <p>
-      <a href="/ai/contact-us?product=ai-index"
-        >Contact our experts</a
-      >
-      to get started with consulting, training or outsourced operations.
-    </p>
-  </div>
 </section>
 
 <section class="p-strip--light is-bordered">


### PR DESCRIPTION
## Done

Add ai/consulting page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/ai/consulting](http://0.0.0.0:8001/ai/consulting)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Got to the page and make sure it complies with the [copy doc](https://docs.google.com/document/d/19Mx1zRJKqH2hz5kRF_oDsgyFUw67FgJvW4I_OGda-wk/edit#heading=h.qo896jpcbdg0)


## Issue / Card

Fixes #5083 


