### PR TITLE
Group pages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 Django==2.2
 django-prometheus==1.0.15
-canonicalwebteam.blog==1.5.0
+canonicalwebteam.blog==1.5.1
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.django_views==1.3.4
 canonicalwebteam.get-feeds==0.2.4
-canonicalwebteam.http==0.1.6
+canonicalwebteam.http==1.0.1
 canonicalwebteam.versioned_static==1.0.2
 canonicalwebteam.yaml-responses[django]==1.1.0
 whitenoise==4.1.2

--- a/templates/blog/cloud-and-server.html
+++ b/templates/blog/cloud-and-server.html
@@ -1,0 +1,6 @@
+{% extends "templates/one-column.html" %} 
+{% block content %} 
+{% for article in articles %} 
+{% include 'blog/blog-card.html' %} 
+{% endfor %} 
+{% endblock %}

--- a/templates/blog/desktop.html
+++ b/templates/blog/desktop.html
@@ -1,0 +1,6 @@
+{% extends "templates/one-column.html" %} 
+{% block content %} 
+{% for article in articles %} 
+{% include 'blog/blog-card.html' %} 
+{% endfor %} 
+{% endblock %}

--- a/templates/blog/internet-of-things.html
+++ b/templates/blog/internet-of-things.html
@@ -1,0 +1,6 @@
+{% extends "templates/one-column.html" %} 
+{% block content %} 
+{% for article in articles %} 
+{% include 'blog/blog-card.html' %} 
+{% endfor %} 
+{% endblock %}

--- a/templates/blog/press-centre.html
+++ b/templates/blog/press-centre.html
@@ -1,0 +1,6 @@
+{% extends "templates/one-column.html" %} 
+{% block content %} 
+{% for article in articles %} 
+{% include 'blog/blog-card.html' %} 
+{% endfor %} 
+{% endblock %}

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -1,9 +1,11 @@
 # Third party modules
-from django.conf.urls import include, url
+from django.conf.urls import url, include
+from django.urls import path
 from canonicalwebteam.yaml_responses.django_helpers import (
     create_deleted_views,
     create_redirect_views,
 )
+from canonicalwebteam.blog.django.views import group
 
 # Local code
 from .views import UbuntuTemplateFinder, DownloadView, ResourcesView, search
@@ -12,7 +14,40 @@ from .views import UbuntuTemplateFinder, DownloadView, ResourcesView, search
 urlpatterns = create_redirect_views()
 urlpatterns += create_deleted_views()
 urlpatterns += [
-    url(r"blog", include("canonicalwebteam.blog.django.urls")),
+    path(
+        r"blog/cloud-and-server",
+        group,
+        {
+            "slug": "cloud-and-server",
+            "template_path": "blog/cloud-and-server.html",
+        },
+        name="group",
+    ),
+    path(
+        r"blog/desktop",
+        group,
+        {"slug": "desktop", "template_path": "blog/desktop.html"},
+        name="group",
+    ),
+    path(
+        r"blog/press-centre",
+        group,
+        {
+            "slug": "canonical-announcements",
+            "template_path": "blog/press-centre.html",
+        },
+        name="group",
+    ),
+    path(
+        r"blog/internet-of-things",
+        group,
+        {
+            "slug": "internet-of-things",
+            "template_path": "blog/internet-of-things.html",
+        },
+        name="group",
+    ),
+    path(r"blog", include("canonicalwebteam.blog.django.urls")),
     url("", include("django_prometheus.urls")),
     url(
         r"^(?P<template>download/(desktop|server|cloud)/thank-you)$",

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -22,7 +22,7 @@ except ImportError:
 # Search service
 if settings.SEARCH_API_KEY:
     search_session = CachedSession(
-        expire_after=settings.SEARCH_CACHE_EXPIRY_SECONDS
+        fallback_cache_duration=settings.SEARCH_CACHE_EXPIRY_SECONDS
     )
 
 


### PR DESCRIPTION
**Depends on** https://github.com/canonical-web-and-design/www.ubuntu.com/pull/5071
## Done
- Updates to blog module 1.5.1 https://github.com/canonical-web-and-design/canonicalwebteam.blog/pull/40 
- Create a dummy template for `cloud-and-server` (see blog module for more info on which groups are available)

## QA

**Template are in an early state, and styling was not part of this PR**

- `./run`
- go to `http://localhost:8001/blog/cloud-and-server` and make sure only articles from that group are shown
- go to `http://localhost:8001/blog/cloud-and-server?category=case-studies` and make sure only articles from that group+category are shown



## Issue / Card

Fixes https://github.com/canonical-web-and-design/base-squad/issues/455
Fixes https://github.com/canonical-web-and-design/base-squad/issues/456


