### PR TITLE
Update snapcraft links on /desktop/developers page

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -163,7 +163,7 @@
             </g>
           </g>
         </svg>
-        <h3 class="p-card__title p-heading--four"><a href="https://docs.snapcraft.io/core/install">Installation instructions&nbsp;&rsaquo;</a></h3>
+        <h3 class="p-card__title p-heading--four"><a href="https://docs.snapcraft.io/installing-snapd">Installation instructions&nbsp;&rsaquo;</a></h3>
       </div>
       <div class="col-4 p-card u-align--center">
         <svg class="p-card__icon" viewBox="0 0 37 32">
@@ -180,7 +180,7 @@
             </g>
           </g>
         </svg>
-        <h3 class="p-card__title p-heading--four"><a href="https://docs.snapcraft.io/core/usage">Use snap commands&nbsp;&rsaquo;</a></h3>
+        <h3 class="p-card__title p-heading--four"><a href="https://docs.snapcraft.io/getting-started">Use snap commands&nbsp;&rsaquo;</a></h3>
       </div>
       <div class="col-4 p-card u-align--center ">
         <svg class="p-card__icon" viewBox="0 0 32 28">
@@ -192,7 +192,7 @@
             </g>
           </g>
         </svg>
-        <h3 class="p-card__title p-heading--four"><a href="https://docs.snapcraft.io/build-snaps/">Build your first snap&nbsp;&rsaquo;</a></h3>
+        <h3 class="p-card__title p-heading--four"><a href="https://snapcraft.io/first-snap">Build your first snap&nbsp;&rsaquo;</a></h3>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

- Updated snapcraft links on /desktop/developers page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/developers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the snapcraft links are as per the [copydoc](https://docs.google.com/document/d/1VJ3xT2ViC-CvL0UmsAUzpYFmvpuqUP4AbpnlPm8tqOA/edit)


## Issue / Card

Fixes #5088 
