### PR TITLE
Remove canal from /pricing/consulting

### DIFF
--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -27,10 +27,10 @@
       <li class="p-list__item is-ticked">High availability</li>
       <li class="p-list__item is-ticked">Cloud, VMware, OpenStack</li>
       <li class="p-list__item is-ticked">Logging, monitoring,  alerting</li>
-      <li class="p-list__item is-ticked">Calico, Canal, Flannel</li>
+      <li class="p-list__item is-ticked">Calico and Flannel</li>
       <li class="p-list__item is-ticked">Three days standard training</li>
     </ul>
-  </div>
+  </div>,
   <div class="col-4 p-card">
     <div class="p-card__header">
       <h2 class="p-heading--four">Discoverer Plus</h2>

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -30,7 +30,7 @@
       <li class="p-list__item is-ticked">Calico and Flannel</li>
       <li class="p-list__item is-ticked">Three days standard training</li>
     </ul>
-  </div>,
+  </div>
   <div class="col-4 p-card">
     <div class="p-card__header">
       <h2 class="p-heading--four">Discoverer Plus</h2>


### PR DESCRIPTION
## Done

Remove canal from /pricing/consulting

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/pricing/consulting](http://0.0.0.0:8001/pricing/consulting)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1sXeOQ9eLq53NcfbrorYstHkZYTdut33jbN5LyHoDdYY/edit#)


## Issue / Card

Fixes #5110
