### PR TITLE
Change sector heading in footer style

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -109,6 +109,12 @@
 
       span {
         padding-left: $sp-x-small;
+
+        @media only screen and (min-width: $breakpoint-medium) {
+          color: $color-dark;
+          font-weight: normal;
+          padding-left: 0;
+        }
       }
 
       a:link,

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -107,16 +107,6 @@
         font-size: .8125rem;
       }
 
-      span {
-        padding-left: $sp-x-small;
-
-        @media only screen and (min-width: $breakpoint-medium) {
-          color: $color-dark;
-          font-weight: normal;
-          padding-left: 0;
-        }
-      }
-
       a:link,
       a:visited {
         color: $color-mid-dark;
@@ -154,13 +144,13 @@
       }
 
       &.p-footer__title-text {
-        @media only screen and (min-width: $breakpoint-small) {
+        @media only screen and (min-width: $breakpoint-medium) {
           color: $color-dark;
           font-weight: 400;
         }
 
-        @media only screen and (max-width: $breakpoint-small) {
-          padding-left: 0.25rem;
+        @media only screen and (max-width: $breakpoint-medium) {
+          padding-left: $sp-x-small;
 
           a {
             color: $color-mid-dark;

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -107,6 +107,10 @@
         font-size: .8125rem;
       }
 
+      span {
+        padding-left: $sp-x-small;
+      }
+
       a:link,
       a:visited {
         color: $color-mid-dark;

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -36,7 +36,7 @@
         <ul class="p-footer__links">
           <li class="p-footer__item p-footer__item--spaced">
             <h2 class="p-footer__title">
-                <span>Sectors</span>
+              <span>Sectors</span>
             </h2>
             <ul class="second-level-nav">
               <li class="p-footer-list--margin"><a href="/telecommunications">Telco</a></li>

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -35,7 +35,7 @@
       <div class="p-footer__nav-col col-2 u-no-margin--bottom last-col">
         <ul class="p-footer__links">
           <li class="p-footer__item p-footer__item--spaced">
-            <h2 class="p-footer__title">
+            <h2 class="p-footer__title p-footer__title-text">
               <span>Sectors</span>
             </h2>
             <ul class="second-level-nav">

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -35,7 +35,7 @@
       <div class="p-footer__nav-col col-2 u-no-margin--bottom last-col">
         <ul class="p-footer__links">
           <li class="p-footer__item p-footer__item--spaced">
-            <h2 class="p-footer__title p-footer__title-text">
+            <h2 class="p-footer__title">
                 <span>Sectors</span>
             </h2>
             <ul class="second-level-nav">


### PR DESCRIPTION
## Done

Display "sectors" heading in the footer correctly for small screen sizes

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to the home page and resize the widow to 550px wide and than make it bigger to 650px wide. Make sure the style of the "sector" heading in the footer remains consistent.


## Issue / Card

Fixes #4904 

