### PR TITLE
1124 ubuntu 19.04 takeover and webinar

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -32,6 +32,7 @@
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
+  {% include "takeovers/_1904-webinar_takeover.html" %}
   {% include "takeovers/_cloud-init-takeover.html" %}
   {% include "takeovers/_openstack_security_takeover.html" %}
   {% include "takeovers/_14-04-esm.html" %}

--- a/templates/takeovers/_1904-webinar_takeover.html
+++ b/templates/takeovers/_1904-webinar_takeover.html
@@ -1,0 +1,74 @@
+<section class="p-strip--dark p-takeover js-takeover">
+  <div class="row u-clearfix u-vertically-center">
+    <div class="col-8">
+      <h1>What’s new in Ubuntu 19.04?</h1>
+      <p class="p-heading--four u-sv2">
+        From the Linux Kernel to Openstack and Kubernetes: find out why the latest Ubuntu release is our most advanced to date.      
+      </p>
+      <a
+        href="/engage/19-04-webinar?utm_source=takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
+        onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 webinar takeover', 'eventLabel' : 'What’s new in Ubuntu 19.04?', 'eventValue' : undefined });"
+        class="p-button--positive u-hide--small"
+        >Watch the webinar
+      </a>
+     </div>
+    <div class="col-4">
+      <p class="p-takeover__image u-align-text--center">
+        <img
+          src="{{ ASSET_SERVER_URL }}a76865fa-disco_dingo_mascot.svg"
+          alt=""
+        />
+      </p>
+      <p class="u-hide--medium u-hide--large">
+        <a
+          href="/engage/19-04-webinar?utm_source=takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
+          onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 webinar takeover', 'eventLabel' : 'What’s new in Ubuntu 19.04?', 'eventValue' : undefined });"
+          class="p-button--positive"
+          >Watch the webinar
+        </a>
+      </p>
+    </div>
+  </div>
+  <style>
+    .p-takeover {
+      background-image: url("{{ ASSET_SERVER_URL }}8951dc67-suru-left.svg"),
+        url("{{ ASSET_SERVER_URL }}55079ac4-suru-right.svg"),
+        linear-gradient(
+          0deg,
+          #dd4814 0%,
+          #be3d2f 23%,
+          #76236d 75%,
+          #531a4d 100%
+        );
+      background-position: left, right;
+      background-repeat: no-repeat, no-repeat;
+      background-size: auto 100%, auto 100%, cover;
+    }
+
+    .p-takeover__image {
+      mix-blend-mode: overlay;
+    }
+
+    @media (max-width: 874px) {
+      .p-takeover {
+        background-image: linear-gradient(
+          0deg,
+          #dd4814 0%,
+          #b83b34 22%,
+          #76236d 60%,
+          #531a4d 100%
+        );
+      }
+      .p-takeover__image {
+        width: 188px;
+      }
+    }
+
+    @media (max-width: 620px) {
+      .p-takeover__image {
+        opacity: 0.4;
+        mix-blend-mode: normal;
+      }
+    }
+  </style>
+</section>

--- a/templates/takeovers/_1904-webinar_takeover.html
+++ b/templates/takeovers/_1904-webinar_takeover.html
@@ -7,7 +7,6 @@
       </p>
       <a
         href="/engage/19-04-webinar?utm_source=takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
-        onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 webinar takeover', 'eventLabel' : 'What’s new in Ubuntu 19.04?', 'eventValue' : undefined });"
         class="p-button--positive u-hide--small"
         >Watch the webinar
       </a>
@@ -22,7 +21,6 @@
       <p class="u-hide--medium u-hide--large">
         <a
           href="/engage/19-04-webinar?utm_source=takeover&utm_campaign=CY19_DC_19.04_WBN_19.04"
-          onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '19.04 webinar takeover', 'eventLabel' : 'What’s new in Ubuntu 19.04?', 'eventValue' : undefined });"
           class="p-button--positive"
           >Watch the webinar
         </a>


### PR DESCRIPTION
## Done

Add Ubuntu 19.04 webinar takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to home page and refresh until you see the Ubuntu 19.04 webinar takeover
- Check the [design](https://github.com/canonical-web-and-design/web-squad/issues/1083)
- Make sure the text matches [this](https://github.com/canonical-web-and-design/web-squad/issues/1124)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1124
