### PR TITLE
Skip global takeovers for fr and de users

### DIFF
--- a/templates/takeovers/_1904-webinar_takeover.html
+++ b/templates/takeovers/_1904-webinar_takeover.html
@@ -1,4 +1,4 @@
-<section class="p-strip--dark p-takeover js-takeover">
+<section class="p-strip--dark p-takeover js-takeover" lang-skip="fr de">
   <div class="row u-clearfix u-vertically-center">
     <div class="col-8">
       <h1>What’s new in Ubuntu 19.04?</h1>

--- a/templates/takeovers/_cloud-init-takeover.html
+++ b/templates/takeovers/_cloud-init-takeover.html
@@ -1,4 +1,4 @@
-<section class="p-strip--dark p-takeover js-takeover">
+<section class="p-strip--dark p-takeover js-takeover" lang-skip="fr de">
   <div class="row u-clearfix u-vertically-center">
     <div class="col-7">
       <h1>Cloud-init</h1>

--- a/templates/takeovers/_iot-devops_takeover.html
+++ b/templates/takeovers/_iot-devops_takeover.html
@@ -1,4 +1,4 @@
-<section class="p-strip--dark is-shallow p-takeover js-takeover">
+<section class="p-strip--dark is-shallow p-takeover js-takeover" lang-skip="fr de">
     <div class="row u-clearfix u-vertically-center">
       <div class="col-7">
         <h1>Transform the IoT DevOps journey</h1>

--- a/templates/takeovers/_openstack_security_takeover.html
+++ b/templates/takeovers/_openstack_security_takeover.html
@@ -1,4 +1,4 @@
-<section class="p-strip--dark p-takeover js-takeover">
+<section class="p-strip--dark p-takeover js-takeover" lang-skip="fr de">
   <div class="row u-clearfix u-vertically-center">
     <div class="col-8">
       <h1>Private cloud security</h1>


### PR DESCRIPTION
## Done

* Skipping global takeovers for non-en users users who have localized ones

## QA

- If it's not already the case :eyes: , change your browser language to French.
- Visit the demo site and refresh the homepage multiple times.
- You should only see takeovers in your favourite language.