### PR TITLE
Add logic to including form validation

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -92,7 +92,10 @@
     <!-- footer content goes here -->
     {% include "templates/footer.html" %}
     {% include "shared/_polyfill.html" %}
-    {% include "shared/forms/_form-validation.html" %}
+    {% if "whitepapers" not in request.path  %}
+    <!-- form validation -->
+      {% include "shared/forms/_form-validation.html" %}
+    {% endif %}
     <script src="{% versioned_static 'js/build/main.min.js' %}"></script>
     <script src="{{ ASSET_SERVER_URL }}f5bf3854-respond.min.js"></script>
     {% block footer_extra %}{% endblock %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -92,7 +92,7 @@
     <!-- footer content goes here -->
     {% include "templates/footer.html" %}
     {% include "shared/_polyfill.html" %}
-    {% if "whitepapers" not in request.path  %}
+    {% if "/whitepapers" not in request.path  %}
     <!-- form validation -->
       {% include "shared/forms/_form-validation.html" %}
     {% endif %}


### PR DESCRIPTION
## Done

- add logic to NOT load shared/forms/_form-validation.html for the path /whitepapers

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/whitepapers/robotics](http://0.0.0.0:8001/whitepapers/robotics)
- See that the form works and the content is revealed
- Go to http://0.0.0.0:8001/#get-in-touch
- See that the form works

## Issue / Card

Fixes #5127