### PR TITLE
Add link to ESXi page on data privacy page

### DIFF
--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -42,6 +42,7 @@
         <li class="p-list__item"><a href="/legal/data-privacy/contact">Contact us and enquiries privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/sso">Single sign on privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/partner-portal">Partner Portal privacy notice&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/data-privacy/esxi">ESXi privacy notice&nbsp;&rsaquo;</a></li>
       </ul>
       <h2 id="information-we-collect-from-you">Information we collect from you</h2>
       <ul class="p-list">


### PR DESCRIPTION
## Done

Add link to ESXi page on data privacy page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/legal/data-privacy](http://0.0.0.0:8001/legal/data-privacy)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure it complies with the [copy doc](https://docs.google.com/document/d/1AlOE2_-BqZNP4hiiuf8kZney8g1zvqAlDYl2u3X6m6I/edit)


## Issue / Card

Fixes #5132 