### PR TITLE
Update low res logos on /download/iot page

### DIFF
--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -43,7 +43,7 @@
         </p>
       </div>
       <div class="col-3 p-divider__block">
-        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}1f53b707-JOULE-LOGO.png?h=35" alt="Intel Joule" height="35">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}db101789-intel-joule.svg?h=35" alt="Intel Joule" height="35">
         <p>
           <a href="/download/iot/intel-joule-desktop">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
         </p>
@@ -120,7 +120,7 @@
           </li>
           <li class="p-matrix__item">
             <div class="p-matrix__content">
-              <p><img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}1f53b707-JOULE-LOGO.png?h=35" height="35" alt="Intel Joule"></p>
+              <p><img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}db101789-intel-joule.svg?h=35" height="35" alt="Intel Joule"></p>
               <p><a href="/download/iot/intel-joule">Install Ubuntu Core 16&nbsp;&rsaquo;</a></p>
             </div>
           </li>

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -37,7 +37,7 @@
     </div>
     <div class="row p-divider">
       <div class="col-3 p-divider__block">
-        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}bb9f2504-2018-logo-artik-01.png"  height="50" alt="Samsung Artik">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}472aceb3-samsung-artik-logo.svg?w=93" width="93" alt="Samsung Artik">
         <p>
           <a href="/download/iot/samsung-artik-5-10-server">Install Ubuntu Server&nbsp;&rsaquo;</a>
         </p>
@@ -55,7 +55,7 @@
         </p>
       </div>
       <div class="col-3 p-divider__block">
-        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}8cb47950-g46.png?h=35" height="35" alt="Up2">
+        <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}88444b11-logo-up2.svg?w=45" width="45" alt="Up2">
         <p>
           <a href="/download/iot/intel-nuc-desktop">Install Ubuntu Server&nbsp;&rsaquo;</a>
         </p>
@@ -88,7 +88,7 @@
       <ul class="p-matrix u-clearfix">
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <p><img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/e3a042a7-raspberrypi-card.png?w=115" width="115" alt="Raspberry Pi"></p>
+            <p><img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/977f2b7a-raspberry+pi+horizontal.svg?w=115" width="115" alt="Raspberry Pi"></p>
             <p>Install Ubuntu Core 18 on:</p>
             <p><a href="/download/iot/raspberry-pi-2-3-core">Raspberry Pi 2 or  3&nbsp;&rsaquo;</a><br />
               <a href="/download/iot/raspberry-pi-compute-module-3">Raspberry Pi CM3&nbsp;&rsaquo;</a></p>
@@ -102,19 +102,19 @@
           </li>
           <li class="p-matrix__item">
             <div class="p-matrix__content">
-              <p><img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/ff8c23f4-logo-pic.png?h=35" height="35" alt="Intel IEI TANK 870"></p>
+              <p><img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/db577ec7-tank-logo.svg?w=115" width="115" alt="Intel IEI TANK 870"></p>
               <p><a href="/download/iot/intel-iei-tank-870">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
             </div>
           </li>
           <li class="p-matrix__item">
             <div class="p-matrix__content">
-              <p><img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/d9ccf84b-qualcoom.png?h=35" height="35" alt="Qualcomm Snapdragon"></p>
+              <p><img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/2a6d29c9-snapdragon.svg?w=99" width="99" alt="Qualcomm Snapdragon"></p>
               <p><a href="/download/iot/qualcomm-dragonboard-410c">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
             </div>
           </li>
           <li class="p-matrix__item">
             <div class="p-matrix__content">
-              <p><img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}bb9f2504-2018-logo-artik-01.png?h=40"  height="40" alt="Samsung Artik"></p>
+              <p><img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}472aceb3-samsung-artik-logo.svg?w=93"  width="93" alt="Samsung Artik"></p>
               <p><a href="/download/iot/samsung-artik-5-10">Install Ubuntu Core 16&nbsp;&rsaquo;</a></p>
             </div>
           </li>


### PR DESCRIPTION
## Done

Updated logos for:
- Artik
- Intel JOULE
- Raspberry Pi
- Snapdragon
- Tank
- Up2

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/iot](http://0.0.0.0:8001/download/iot)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the logos listed above aren't of low resolution.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1098
