### PR TITLE
Remove partners logo sections

### DIFF
--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -204,25 +204,6 @@
   </div>
 </div>
 
-
-<div class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      {% include "shared/_partner-logos.html" with title="A selection of our hardware partners" json_feed_url="http://partners.ubuntu.com/partners.json?programme__name=Desktop&featured=true" feed_item_limit=10 %}
-      <p class="u-align--center"><a class="p-link--external" href="https://certification.ubuntu.com">View all certified hardware partners</a></p>
-    </div>
-  </div>
-</div>
-
-<div class="p-strip is-deep">
-  <div class="row">
-    <div class="col-12">
-      {% include "shared/_partner-logos.html" with title="A selection of our software partners" json_feed_url="http://partners.ubuntu.com/partners.json?programme__name=OpenStack&service-offered=softwarecontent-publisher" feed_item_limit=10 %}
-      <p class="u-align--center"><a class="p-link--external" href="/partners/certified-software">View all certified software partners</a></p>
-    </div>
-  </div>
-</div>
-
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_server_download" second_item="_server_contact_us" third_item="_cloud_further_reading" %}
 {% include "shared/forms/interactive/_support.html" with formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 


### PR DESCRIPTION
## Done

Remove partners logo sections

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/server/hyperscale](http://0.0.0.0:8001/server/hyperscale)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure the hardware and software partners sections are removed


## Issue / Card

Fixes #5138 
