### PR TITLE
Change learn how to make a snap link

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -93,7 +93,7 @@
           <li class="p-list__item is-ticked">Easy to create and distribute</li>
           <li class="p-list__item is-ticked">Widely adopted by industry leaders</li>
         </ul>
-        <p><a href="http://snapcraft.io/?from=iotpage" class="p-link--external">Learn how to make a snap</a></p>
+        <p><a href="https://snapcraft.io/first-snap?from=iotpage" class="p-link--external">Learn how to make a snap</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

Change learn how to make a snap link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/internet-of-things](http://0.0.0.0:8001/internet-of-things)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure the "Learn how to make a snap" link takes you to https://snapcraft.io/first-snap


## Issue / Card

Fixes #5100 
