### PR TITLE
Replace IoT DevOps webinar takeover with the whitepaper takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -36,7 +36,7 @@
   {% include "takeovers/_cloud-init-takeover.html" %}
   {% include "takeovers/_openstack_security_takeover.html" %}
   {% include "takeovers/_14-04-esm.html" %}
-  {% include "takeovers/_devops-iot-webinar_takeover.html" %}
+  {% include "takeovers/_iot-devops_takeover.html" %}
 {% endblock takeover_content %}
 
 


### PR DESCRIPTION
## Done

Replace IoT DevOps webinar takeover with the whitepaper takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/) 
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the home page until the IoT DevOps whitepaper takeover comes up. Make sure the IoT DevOps webinar takeover is not shown anymore.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1137

