### PR TITLE
Add a redirect for ubuntu.com/cc-eal for better search result hits

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -123,6 +123,7 @@ category/product/(server|ubuntu-server-edition)/?: /server
 category/product/ubuntu-advantage/?: /support
 category/product/ubuntu-light/?: http://lubuntu.net/
 cc/?: "/security/certifications"
+cc-eal/?: "/security/certifications"
 cis/?: "/security/certifications"
 cloud/?: "/public-cloud"
 cloud/awsome/?: "https://launchpad.net/awsome"


### PR DESCRIPTION
Came out an Ubuntu Advantage Client CLI user experience review in Lyon.
This is a prerequisite route for fixing UA Client in issue
https://github.com/CanonicalLtd/ubuntu-advantage-client/issues/502

Fixes: #5163

## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
