### PR TITLE
Fix openstack made easy french form

### DIFF
--- a/templates/engage/fr/openstack-made-easy.html
+++ b/templates/engage/fr/openstack-made-easy.html
@@ -39,7 +39,80 @@
       </ul>
     </div>
     <div class="col-5">
-      {% include "engage/shared/_fr_engage_form.html" with id="3323" returnURL="https://www.ubuntu.com/support/thank-you" cta="Télécharger l'eBook" %}
+            <!-- MARKETO FORM -->
+      <script src="{{ ASSET_SERVER_URL }}37b1db88-jquery.min.js"></script>
+      <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
+      <script src="{{ ASSET_SERVER_URL }}6ce35d3e-jquery-ui.min.js"></script>‌​
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3323" class="marketo-form" style="margin-top:-1em;">
+        <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+          <ul class="p-list u-no-margin--bottom">
+            <li class="mktFormReq mktField p-list__item">
+              <label for="FirstName" class="mktoLabel ">Prénom :</label>
+              <input required id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="First Name">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="LastName" class="mktoLabel ">Nom :</label>
+              <input required id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Last Name">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="Email" class="mktoLabel ">Email :</label>
+              <input required id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" aria-label="Email">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="Company" class="mktoLabel ">Entreprise :</label>
+              <input required id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Company Name">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="Title" class="mktoLabel ">Fonction :</label>
+              <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
+            </li>
+            <li class="mktFormReq mktField">
+              <label for="Phone" class="mktoLabel ">Téléphone :</label>
+              <input required id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel" aria-label="Phone Number">
+            </li>
+            <li class="mktField">
+              <input name="utm_campaign" class="mktoField mktoFormCol" value="{{utm_campaign}}" type="hidden" aria-label="utm_campaign">
+            </li>
+            <li class="mktField">
+              <input name="utm_medium" class="mktoField mktoFormCol" value="{{utm_medium}}" type="hidden" aria-label="utm_medium">
+            </li>
+            <li class="mktField">
+              <input name="utm_source" class="mktoField mktoFormCol" value="{{utm_source}}" type="hidden" aria-label="utm_source">
+            </li>
+            <li class="mktField">
+              <input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" class="mktoField" type="checkbox">
+              <label for="canonicalUpdatesOptIn" class="mktoLabel">J'accepte de recevoir des informations sur les produits et services de Canonical.</label>
+            </li>
+            <li class="mktField">
+              <p>En soumettant ce formulaire, je confirme que j'ai lu et que j'accepte les conditions suivantes : <a href="/legal/data-privacy" target="_blank" class="mchNoDecorate">Politique de confidentialité</a></p>
+              <input name="RichText" type="hidden" aria-label="RichText">
+            </li>
+            <li class="p-list__item">
+              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+            </li>
+            <li class="mktField">
+              <input name="Consent_to_Processing__c" class="mktoField  mktoFormCol" value="Yes" type="hidden" aria-label="Consent_to_Processing__c">
+            </li>
+            <li class="mktField">
+              <button type="submit" class="mktoButton">Télécharger l'eBook</button>
+              <input name="formid" class="mktoField" value="3323" type="hidden" aria-label="formid">
+              <input name="lpId" class="mktoField " value="" type="hidden" aria-label="lpId">
+              <input name="subId" class="mktoField " value="" type="hidden" aria-label="subId">
+              <input name="munchkinId" class="mktoField " value="" type="hidden" aria-label="munchkinId">
+              <input name="lpurl" class="mktoField " value="" type="hidden" aria-label="lpurl">
+              <input name="cr" class="mktoField " value="" type="hidden" aria-label="cr">
+              <input name="kw" class="mktoField " value="" type="hidden" aria-label="kw">
+              <input name="q" class="mktoField " value="" type="hidden" aria-label="q">
+            </li>
+          </ul>
+        </fieldset>
+        <input type="hidden" name="returnURL" value="https://pages.ubuntu.com/openstack-made-easy-fr-TY.html" aria-label="returnURL">
+        <input type="hidden" name="retURL" value="https://pages.ubuntu.com/openstack-made-easy-fr-TY.html" aria-label="retURL">
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="https://pages.ubuntu.com/openstack-made-easy-fr-TY.html" />
+      </form>
+      <script src="{{ ASSET_SERVER_URL }}f97fa297-stateCountry.js"></script>
+
+      <!-- /MARKETO FORM -->
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

With the recent form work, this one was turned into a contact form, hence had 1) wrong fields 2) wrong return URL
* Reverted to the previous form

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to `/engage/fr/openstack-made-easy`, fill the form, ensure you can download the ebook
