### PR TITLE
vf2.0alpha: subnav fix

### DIFF
--- a/static/sass/_global-settings.scss
+++ b/static/sass/_global-settings.scss
@@ -1,9 +1,8 @@
-$breakpoint-medium:    875px;
-$viewport-threshold:      1281px;
-$color-brand:             #e95420;
+$breakpoint-medium: 875px;
+$viewport-threshold: 1281px;
+$color-brand: #e95420;
 $sp-medium-small: 1rem * .85 !default;
 $sp-medium-large: 1rem * 1.15 !default;
-$grid-max-width: 68rem;
 $nav-bg-color: #333;
 $circle-of-friends-compensation: 0; // padding compensation to create visually equal margins;
 $contrast-ratio: 5%;

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -59,7 +59,7 @@
 </div>
 {% if breadcrumbs and breadcrumbs.children and breadcrumbs.children|length > 1 or breadcrumbs.grandchildren %}
 <nav class="p-navigation--secondary">
-  <div class="row">
+  <div class="u-fixed-width">
     <a class="p-navigation--secondary__banner u-hide--nav-threshold-down" href="{{ breadcrumbs.section.path }}">
       <h5 class="p-navigation--secondary__logo">
         {{ breadcrumbs.section.title }}

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -3,7 +3,7 @@
 <footer class="p-footer p-strip u-clearfix">
   <div class="row p-footer__container">
     <p class="u-hide--medium u-hide--large link-to-top"><a href="#"><small>Back to top</small></a></p>
-    <nav id="main-navigation" class="p-footer__nav u-clearfix">
+    <nav id="main-navigation" class="p-footer__nav row">
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
           {% include 'templates/_footer_item.html' with section=nav_sections.openstack %}


### PR DESCRIPTION
## Done

The new grid is a bit more strict. Anything placed inside (with or without col-* classes), needs to span a number of columns. I've set the default behaviour to 12, i.e. full width of the grid.

In cases where an item needs to be as wide as its content, using a .row is not ideal. Instead, I propose a .u-fixed-width class, which sets max-width and paddings matching .row, but doesn't force the content inside to span any number of columns. This could be useful for tabs, menus etc. and can be placed on the pattern div, which can reduce nesting.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
