### PR TITLE
Add product context handling to forms

### DIFF
--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -17,6 +17,18 @@
     contactButtons.forEach(function(contactButton) {
       contactButton.addEventListener('click', function(e) {
         e.preventDefault();
+        // Capture current path and stringify 
+        // eg. /kubernetes/install -> kubernetes-install
+        // fallbacks to "global"
+        var product = window.location.pathname.split("/").slice(1).join("-") || "global";
+        // If present, override with product parameter from button URL
+        contactButton.search.split("&").forEach(function(param) {
+          if (param.startsWith("product") || param.startsWith("?product")) {
+            product = param.split("=")[1];
+          } 
+        });
+        // Set product in form field
+        document.getElementById("product-context").value = product;
         open();
       });
     });

--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -17,22 +17,7 @@
     contactButtons.forEach(function(contactButton) {
       contactButton.addEventListener('click', function(e) {
         e.preventDefault();
-        // Capture current path and stringify
-        // eg. /kubernetes/install -> kubernetes-install
-        // fallbacks to "global"
-        var product = window.location.pathname.split("/").slice(1).join("-") || "global";
-        // If present, override with product parameter from button URL
-        contactButton.search.split("&").forEach(function(param) {
-          if (param.startsWith("product") || param.startsWith("?product")) {
-            product = param.split("=")[1];
-          }
-        });
-
-        // Set product in form field
-        var productContext = document.getElementById("product-context");
-        if (productContext) {
-          productContext.value = product;
-        }
+        setProductContext(contactButton);
         open();
       });
     });
@@ -103,6 +88,29 @@
         }
       });
     });
+
+    function setProductContext(contactButton) {
+      console.log('setProductContext');
+      // Capture current path and stringify
+      // eg. /kubernetes/install -> kubernetes-install
+      // fallbacks to "global"
+      var product = window.location.pathname.split("/").slice(1).join("-") || "global";
+      // If present, override with product parameter from button URL
+      if (contactButton) {
+        contactButton.search.split("&").forEach(function(param) {
+          if (param.startsWith("product") || param.startsWith("?product")) {
+            product = param.split("=")[1];
+          }
+        });
+      }
+
+      // Set product in form field
+      var productContext = document.getElementById("product-context");
+      if (productContext) {
+        productContext.value = product;
+      }
+    }
+
 
     // Hack for now but updates the styling based on the thank you panel
     function checkThankYou() {
@@ -218,6 +226,7 @@
 
     // Opens the form when the initial hash matches the trigger
     if (window.location.hash === triggeringHash) {
+      setProductContext();
       open();
     }
 
@@ -225,6 +234,7 @@
     // Listens for hash changes and opens the form if it matches the trigger
     function locationHashChanged() {
       if (window.location.hash === triggeringHash) {
+        setProductContext();
         open();
       }
     }

--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -90,7 +90,6 @@
     });
 
     function setProductContext(contactButton) {
-      console.log('setProductContext');
       // Capture current path and stringify
       // eg. /kubernetes/install -> kubernetes-install
       // fallbacks to "global"

--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -17,7 +17,7 @@
     contactButtons.forEach(function(contactButton) {
       contactButton.addEventListener('click', function(e) {
         e.preventDefault();
-        // Capture current path and stringify 
+        // Capture current path and stringify
         // eg. /kubernetes/install -> kubernetes-install
         // fallbacks to "global"
         var product = window.location.pathname.split("/").slice(1).join("-") || "global";
@@ -25,10 +25,14 @@
         contactButton.search.split("&").forEach(function(param) {
           if (param.startsWith("product") || param.startsWith("?product")) {
             product = param.split("=")[1];
-          } 
+          }
         });
+
         // Set product in form field
-        document.getElementById("product-context").value = product;
+        var productContext = document.getElementById("product-context");
+        if (productContext) {
+          productContext.value = product;
+        }
         open();
       });
     });

--- a/templates/shared/forms/interactive/_bootstack.html
+++ b/templates/shared/forms/interactive/_bootstack.html
@@ -342,6 +342,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_embedded.html
+++ b/templates/shared/forms/interactive/_embedded.html
@@ -194,6 +194,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_general.html
+++ b/templates/shared/forms/interactive/_general.html
@@ -227,7 +227,8 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-            </div>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+           </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>

--- a/templates/shared/forms/interactive/_general.html
+++ b/templates/shared/forms/interactive/_general.html
@@ -228,7 +228,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
-           </div>
+            </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>

--- a/templates/shared/forms/interactive/_kubeflow.html
+++ b/templates/shared/forms/interactive/_kubeflow.html
@@ -177,6 +177,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_kubernetes.html
+++ b/templates/shared/forms/interactive/_kubernetes.html
@@ -258,6 +258,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_openstack.html
+++ b/templates/shared/forms/interactive/_openstack.html
@@ -344,6 +344,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_pricing-infra.html
+++ b/templates/shared/forms/interactive/_pricing-infra.html
@@ -198,6 +198,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_robotics.html
+++ b/templates/shared/forms/interactive/_robotics.html
@@ -211,6 +211,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_support.html
+++ b/templates/shared/forms/interactive/_support.html
@@ -197,6 +197,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">


### PR DESCRIPTION
## Done

* Adds the notion of product context to modal forms and pass it to Marketo
* Modal contact forms now inherit the product parameter of the button they are triggered from
* If no parameter is set, the path of the page is passed instead, in the "pathlvl1-pathlvl2-etc" format.


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Click on any contact button, if it triggers a modal form, inspect and ensure it has a hidden "product-context" field set
- Navigate to `/ai`, click on the "Call the experts" button at the top page, inspect and ensure the form has its hidden "product-context" field set to `ai-index`
- Navigate to `/download/iot/raspberry-pi-2-3`, click on the "Contact us" button in the footer, inspect and ensure the form has its hidden "product-context" field set to `download-iot-raspberry-pi-2-3`
