### PR TITLE
Update live takeovers

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -33,9 +33,7 @@
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
   {% include "takeovers/_1904-webinar_takeover.html" %}
-  {% include "takeovers/_cloud-init-takeover.html" %}
-  {% include "takeovers/_openstack_security_takeover.html" %}
-  {% include "takeovers/_14-04-esm.html" %}
+  {% include "takeovers/_lxd-takeover.html" %}
   {% include "takeovers/_iot-devops_takeover.html" %}
 {% endblock takeover_content %}
 


### PR DESCRIPTION
## Done

- Add LXD takeover and landing page live in place of the Cloud-Init whitepaper takeover.

- Remove the OpenStack and ESM takeovers from the rotation.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure lxd takeover is available
- Make sure Cloud-init, OpenStack & ESM takeovers are removed


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1158#event-2358582842