### PR TITLE
4153: Update sass-lint to fail if there are any warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "test": "yarn run lint-scss && yarn run lint-python && yarn run test-python",
     "lint-python": "flake8 webapp/ && black --check --line-length 79 webapp/",
-    "lint-scss": "sass-lint 'static/sass/**/*.scss' --verbose --no-exit -i static/sass/prism.scss",
+    "lint-scss": "sass-lint 'static/sass/**/*.scss' --verbose --no-exit --max-warnings=0 -i static/sass/prism.scss",
     "test-python": "python3 manage.py test",
     "test-links": "python3 manage.py runserver && sleep 2 && linkchecker --threads 2 --ignore-url /usn --ignore-url /resources --ignore-url /search --no-warnings http://127.0.0.1:8000",
     "build-css": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' --no-map",

--- a/static/sass/_layout-whitepapers.scss
+++ b/static/sass/_layout-whitepapers.scss
@@ -40,7 +40,7 @@
 
     .signup-form {
       background: $color-x-light;
-      box-shadow: 0 -30px 30px 0 rgba(255, 255, 255, 0.95);
+      box-shadow: 0 -30px 30px 0 rgba(255, 255, 255, 0.95); //sass-lint:disable-line no-color-literals
       margin-top: -40px;
       padding-top: 40px;
       position: relative;

--- a/static/sass/_pattern_desktop-statistics.scss
+++ b/static/sass/_pattern_desktop-statistics.scss
@@ -33,7 +33,7 @@
 
   @media (min-width: 768px) {
     .p-takeover--stats {
-      background-image: url('https://assets.ubuntu.com/v1/d3edfcd5-left.png'), url('https://assets.ubuntu.com/v1/17508275-right.png'); // sass-lint:disable-line no-url-protocols
+      background-image: url('https://assets.ubuntu.com/v1/d3edfcd5-left.png'), url('https://assets.ubuntu.com/v1/17508275-right.png'); // sass-lint:disable-line no-url-protocols, no-url-domains
       background-position: bottom left, bottom right;
       background-repeat: no-repeat;
       background-size: contain;
@@ -84,7 +84,7 @@
   .p-progress-chart {
     background: $color-x-light;
     border: 1px solid $color-mid-light;
-    box-shadow: 0 1px 5px 1px rgba(17, 17, 17, 0.2);
+    box-shadow: 0 1px 5px 1px rgba(17, 17, 17, 0.2); //sass-lint:disable-line no-color-literals
 
     .p-progress-chart__bar {
       opacity: 1;

--- a/static/sass/print.scss
+++ b/static/sass/print.scss
@@ -37,7 +37,7 @@ pre,
 
 th,
 td {
-    border-bottom: solid #333 !important;
+    border-bottom: solid #333 !important; //sass-lint:disable-line no-color-literals
     border-width: 0 0 1px 0 !important;
 }
 


### PR DESCRIPTION
## Done

- Added `--max-warnings=0` to sass-lint task
- Disabled sass-lint on certain lines where exceptions needed to be made

## QA

- Check out this feature branch
- Run the tests using the command `./run test`
- See that the tests pass
- In any sass file, violate a sass-lint rule by setting `background-color: #000` (which violates the no color literals rule)
- Run `./run test` again
- See that the tests fail

## Issue / Card

Fixes #4153 
