### PR TITLE
3074 remove install open stack video

### DIFF
--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -255,7 +255,6 @@
     <div class="col-6">
       <p class="p-heading--four">Single-node OpenStack installation instructions</p>
       <p>These instructions use LXD, the Linux Container Daemon, to create multiple machine containers on your machine for the various OpenStack services, mimicking a real Openstack cluster.</p>
-      <p>For extra guidance, there is also a video about how to run OpenStack on a single machine.</p>
     </div>
   </div>
 </div>

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -257,12 +257,6 @@
       <p>These instructions use LXD, the Linux Container Daemon, to create multiple machine containers on your machine for the various OpenStack services, mimicking a real Openstack cluster.</p>
       <p>For extra guidance, there is also a video about how to run OpenStack on a single machine.</p>
     </div>
-    <div class="col-6">
-      <p class="p-heading--four">Watch the deployment walkthrough</p>
-      <div class="u-embedded-media">
-        <iframe class="u-embedded-media__element" src="https://player.vimeo.com/video/202195588?color=ffffff&title=0&byline=0&portrait=0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-      </div>
-    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Done

- Removed out-of-date instructional video from `/openstack/install#workstation-deployment`
- Removed line of text from the adjacent copy that referred to the above video

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/openstack/install#workstation-deployment](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there is no video when compared to https://www.ubuntu.com/openstack/install#workstation-deployment
- Ensure that the text matches the [copy doc](https://docs.google.com/document/d/1eQ16jzv6YRGzG_k_C-tUnhM06k6_Ic6fZM-x_ARMzuc/edit)


## Issue / Card

Fixes #3074 
