### PR TITLE
5181: Reduce width of graph image on about page

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -24,8 +24,8 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-10">
-      <img src="{{ ASSET_SERVER_URL }}ddf53747-release-evergreen.png?w=861" width="861" alt="" />
+    <div class="col-8">
+      <img src="{{ ASSET_SERVER_URL }}ddf53747-release-evergreen.png?w=681" width="681" alt="" />
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done

Reduced width of graph image on `/about`

## QA

- Check out this feature branch
- Run the site using the command `./run`
- View the site locally in your web browser at: [/about](http://0.0.0.0:8001/about)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the width of the graph has been reduced to match the second screenshot below.


## Issue / Card

Fixes #5181 

## Screenshots

Original:
<img width="1160" alt="01" src="https://user-images.githubusercontent.com/2376968/58255969-0b3a0a00-7d66-11e9-8f73-e889a94e6fe8.png">

Updated:
<img width="1060" alt="02" src="https://user-images.githubusercontent.com/2376968/58255991-155c0880-7d66-11e9-8684-a7fa10ddfcd9.png">

