### PR TITLE
5148 fix middot alignment

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -263,6 +263,12 @@
       @media only screen and (min-width: $breakpoint-medium) {
         display: inline-block;
       }
+
+      &::after {
+        @media only screen and (max-width: $breakpoint-medium - 1) {
+          display: none;
+        }
+      }
     }
   }
 

--- a/static/sass/_pattern_lists.scss
+++ b/static/sass/_pattern_lists.scss
@@ -214,7 +214,7 @@
       .p-inline-list__item {
         &::after {
           bottom: 0.5rem;
-          right: -.65rem;
+          right: -.75rem;
           top: 1rem;
         }
       }

--- a/static/sass/_pattern_lists.scss
+++ b/static/sass/_pattern_lists.scss
@@ -213,6 +213,7 @@
       // sass-lint:disable-block nesting-depth
       .p-inline-list__item {
         &::after {
+          bottom: 0.5rem;
           right: -.65rem;
           top: 1rem;
         }
@@ -221,12 +222,12 @@
 
     .p-inline-list__item {
       &::after {
+        bottom: 0;
+        height: 0;
+        margin-bottom: auto;
+        margin-top: auto;
         right: -.65em;
-        top: .75rem;
-
-        @media only screen and (max-width: $breakpoint-medium - 1) {
-          display: none;
-        }
+        top: 0;
       }
     }
   }

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -424,6 +424,12 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-intra;
     & .p-inline-list__item {
       @extend %small-text-fixed;
       list-style-type: none;
+
+      &::after {
+        @media only screen and (max-width: $breakpoint-medium - 1) {
+          display: none;
+        }
+      }
     }
 
     &__summary {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -85,7 +85,7 @@
 // either at theme level or in Vanilla Framework directly.
 //
 // Before any feature branch is merged, these bugs should be raised in their
-// respective repos and referenced here, accompanied with a breif description of
+// respective repos and referenced here, accompanied with a brief description of
 // the bug
 
 // XXX Vertically spaced - add vertical margins to an element


### PR DESCRIPTION
## Done

- Fixed alignment of mid-dots in lists on blog pages

## QA

- Check out this feature branch
- Run the site using the command `./run`
- View the site locally in your web browser at: [/blog](http://0.0.0.0:8001/blog)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that mid-dots are vertically centered on these lists:
  - pagination
  - legal links in footer
  - list of links at the bottom of the Enterprise dropdown, in the top navigation
- Visit [/blog/archives](http://0.0.0.0:8001/blog/archives)
- See that the mid-dots on the lists of months are vertically centered


## Issue / Card

Fixes #5148 

## Screenshots
Pagination:
![Screenshot 2019-05-24 at 12 10 56](https://user-images.githubusercontent.com/2376968/58324151-f9b43900-7e1d-11e9-8b31-bfdbf3247c1a.png)

Footer:
![Screenshot 2019-05-24 at 12 11 02](https://user-images.githubusercontent.com/2376968/58324161-ff118380-7e1d-11e9-8062-ba7473dacc4c.png)

Enterprise dropdown:
![Screenshot 2019-05-24 at 12 20 46](https://user-images.githubusercontent.com/2376968/58324298-63344780-7e1e-11e9-83e4-69d5c4113e6a.png)
