### PR TITLE
Add Northstar landing page

### DIFF
--- a/templates/engage/North-Americas-first-autonomous-runway-snowplough-case-study.html
+++ b/templates/engage/North-Americas-first-autonomous-runway-snowplough-case-study.html
@@ -1,0 +1,37 @@
+{% extends "engage/base_engage.html" %}
+
+{% block meta_description %}Northstar Robotics, a Canadian tech start-up founded in 2016, wants to address these challenges by developing autonomous vehicles and wanted to find out if an entire network of vehicles can be powered by a single intelligent control system.{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1uxXjTwzzhOQK7x9xpppWgRNVPLpnYA5BN1Mr1Zp2rHI/edit?ts=5ce644a0#heading=h.ud7r143one49{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="North America’s first autonomous runway snowplough, powered by Ubuntu, may be the answer to seasonal labour shortage" url="#register-section" cta="Download the case study" class="p-strip"%}
+
+<section class="p-strip is-shallow is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <p>Although critical, seasonal tasks can be dull and are often hazardous for human workers to carry out such as clearing snow from busy airport runways in slippery, sub-zero temperatures during winter. Added to this, finding skilled workers to operate the heavy machinery needed to perform these jobs is reportedly in short supply.</p>
+      <p>Northstar Robotics, a Canadian tech start-up founded in 2016, wants to address these challenges by developing autonomous vehicles and wanted to find out if an entire network of vehicles can be powered by a single intelligent control system.</p>
+      <blockquote class="p-pull-quote">
+        <p>Can an entire network of vehicles be powered by a single intelligent control system?</p>
+      </blockquote>
+      <p>The robotics company recently launched a pilot of the first autonomous runway snowplough in North America at Winnipeg Richardson International Airport, Canada’s seventh busiest airport, overcoming many hurdles to ensure its success.</p>
+      <h4>Read about the complex software requirements Northstar Robotics had in order to develop its autonomous snowplough, and:</h4>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Why it believes autonomous robots are the answer to North America’s critical skills shortage.</li>
+        <li class="p-list__item is-ticked">The results of its driverless snowplough deployment at Canada’s Winnipeg Richardson International Airport and what it means going forward.</li>
+        <li class="p-list__item is-ticked">Why it chose support from Ubuntu above alternative distros.</li>
+      </ul>
+    </div>
+    <div class="col-5" id="register-section">
+      {% include "engage/shared/_en_engage_form.html" with id="3402" returnURL="https://pages.ubuntu.com/CStudy_Northstar-TY.html" cta="Download the case study" %}
+    </div>
+  </div>
+  <!-- <style>
+    .p-takeover--northstar {
+      background-image: linear-gradient(134deg, #111111 0%, #212121 100%);
+    }
+  </style> -->
+</section>
+{% endblock content %}

--- a/templates/engage/North-Americas-first-autonomous-runway-snowplough-case-study.html
+++ b/templates/engage/North-Americas-first-autonomous-runway-snowplough-case-study.html
@@ -23,7 +23,7 @@
       </div>
     </div>
     <div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="{{ ASSET_SERVER_URL }}bdbffc9a-northastar-logo.png" alt="">
+      <img src="{{ ASSET_SERVER_URL }}bdbffc9a-northastar-logo.png" width="340px" alt="">
     </div>
   </div>
 </section>
@@ -39,7 +39,7 @@
       <p>The robotics company recently launched a pilot of the first autonomous runway snowplough in North America at Winnipeg Richardson International Airport, Canada&rsquo;s seventh busiest airport, overcoming many hurdles to ensure its success.</p>
       <p>Read about the complex software requirements Northstar Robotics had in order to develop their autonomous snowplough, and:</p>
       <ul class="p-list">
-        <li class="p-list__item is-ticked">Why they believe autonomous robots are the answer to North America's critical skills shortage.</li>
+        <li class="p-list__item is-ticked">Why they believe autonomous robots are the answer to North America&rsquo;s critical skills shortage.</li>
         <li class="p-list__item is-ticked">The results of their driverless snowplough deployment at Canada&rsquo;s Winnipeg Richardson International Airport and what it means going forward.</li>
         <li class="p-list__item is-ticked">Why they chose support from Ubuntu above alternative distros.</li>
       </ul>

--- a/templates/engage/North-Americas-first-autonomous-runway-snowplough-case-study.html
+++ b/templates/engage/North-Americas-first-autonomous-runway-snowplough-case-study.html
@@ -8,11 +8,12 @@
 
 <section class="p-strip--light">
   <div class="row u-equal-height">
-    <div class="col-8 u-vertically-center">
+    <div class="col-7 u-vertically-center">
       <div>
-      <h1 class="u-no-margin--bottom">
-        North America’s first autonomous runway snowplough, powered by Ubuntu, may be the answer to seasonal labour shortage
+      <h1 class="u-no-margin--bottom u-sv3">
+        North America&lsquo;s first autonomous runway snowplough
       </h1>
+      <p class="p-heading--four">The robots helping to address off-highway labour shortages</p>
       <br class="u-hide--medium u-hide--large">
       <p class="u-hide--medium u-hide--large">
         <a href="#register-section" class="p-button--positive">
@@ -21,23 +22,26 @@
       </p>
       </div>
     </div>
+    <div class="col-5 u-hide--small u-align--center u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}bdbffc9a-northastar-logo.png" alt="">
+    </div>
   </div>
 </section>
 
 <section class="p-strip is-shallow is-bordered">
   <div class="row">
     <div class="col-7">
-      <p>Although critical, seasonal tasks can be dull and are often hazardous for human workers to carry out such as clearing snow from busy airport runways in slippery, sub-zero temperatures during winter. Added to this, finding skilled workers to operate the heavy machinery needed to perform these jobs is reportedly in short supply.</p>
-      <p>Northstar Robotics, a Canadian tech start-up founded in 2016, wants to address these challenges by developing autonomous vehicles and wanted to find out if an entire network of vehicles can be powered by a single intelligent control system.</p>
+      <p>Although critical, there are some tasks that are too hazardous for human workers to carry out such as clearing snow from busy airport runways in winter. Added to this, finding skilled workers to operate the heavy machinery needed to perform these jobs is increasingly difficult in a market reportedly in short supply.</p>
+      <p>Northstar Robotics, a Canadian tech start-up founded in 2016, wants to address these challenges by developing autonomous vehicles and wanted to find out if an entire fleet of vehicles can be powered by a single intelligent control system.</p>
       <blockquote class="p-pull-quote">
-        <p>Can an entire network of vehicles be powered by a single intelligent control system?</p>
+        <p>Can an entire fleet of vehicles be powered by a single intelligent control system?</p>
       </blockquote>
-      <p>The robotics company recently launched a pilot of the first autonomous runway snowplough in North America at Winnipeg Richardson International Airport, Canada’s seventh busiest airport, overcoming many hurdles to ensure its success.</p>
-      <p>Read about the complex software requirements Northstar Robotics had in order to develop its autonomous snowplough, and:</p>
+      <p>The robotics company recently launched a pilot of the first autonomous runway snowplough in North America at Winnipeg Richardson International Airport, Canada&rsquo;s seventh busiest airport, overcoming many hurdles to ensure its success.</p>
+      <p>Read about the complex software requirements Northstar Robotics had in order to develop their autonomous snowplough, and:</p>
       <ul class="p-list">
-        <li class="p-list__item is-ticked">Why it believes autonomous robots are the answer to North America’s critical skills shortage.</li>
-        <li class="p-list__item is-ticked">The results of its driverless snowplough deployment at Canada’s Winnipeg Richardson International Airport and what it means going forward.</li>
-        <li class="p-list__item is-ticked">Why it chose support from Ubuntu above alternative distros.</li>
+        <li class="p-list__item is-ticked">Why they believe autonomous robots are the answer to North America's critical skills shortage.</li>
+        <li class="p-list__item is-ticked">The results of their driverless snowplough deployment at Canada&rsquo;s Winnipeg Richardson International Airport and what it means going forward.</li>
+        <li class="p-list__item is-ticked">Why they chose support from Ubuntu above alternative distros.</li>
       </ul>
     </div>
     <div class="col-5" id="register-section">

--- a/templates/engage/North-Americas-first-autonomous-runway-snowplough-case-study.html
+++ b/templates/engage/North-Americas-first-autonomous-runway-snowplough-case-study.html
@@ -28,10 +28,5 @@
       {% include "engage/shared/_en_engage_form.html" with id="3402" returnURL="https://pages.ubuntu.com/CStudy_Northstar-TY.html" cta="Download the case study" %}
     </div>
   </div>
-  <!-- <style>
-    .p-takeover--northstar {
-      background-image: linear-gradient(134deg, #111111 0%, #212121 100%);
-    }
-  </style> -->
 </section>
 {% endblock content %}

--- a/templates/engage/North-Americas-first-autonomous-runway-snowplough-case-study.html
+++ b/templates/engage/North-Americas-first-autonomous-runway-snowplough-case-study.html
@@ -6,7 +6,23 @@
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="North America’s first autonomous runway snowplough, powered by Ubuntu, may be the answer to seasonal labour shortage" url="#register-section" cta="Download the case study" class="p-strip"%}
+<section class="p-strip--light">
+  <div class="row u-equal-height">
+    <div class="col-8 u-vertically-center">
+      <div>
+      <h1 class="u-no-margin--bottom">
+        North America’s first autonomous runway snowplough, powered by Ubuntu, may be the answer to seasonal labour shortage
+      </h1>
+      <br class="u-hide--medium u-hide--large">
+      <p class="u-hide--medium u-hide--large">
+        <a href="#register-section" class="p-button--positive">
+          Download the case study
+        </a>
+      </p>
+      </div>
+    </div>
+  </div>
+</section>
 
 <section class="p-strip is-shallow is-bordered">
   <div class="row">
@@ -17,7 +33,7 @@
         <p>Can an entire network of vehicles be powered by a single intelligent control system?</p>
       </blockquote>
       <p>The robotics company recently launched a pilot of the first autonomous runway snowplough in North America at Winnipeg Richardson International Airport, Canada’s seventh busiest airport, overcoming many hurdles to ensure its success.</p>
-      <h4>Read about the complex software requirements Northstar Robotics had in order to develop its autonomous snowplough, and:</h4>
+      <p>Read about the complex software requirements Northstar Robotics had in order to develop its autonomous snowplough, and:</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Why it believes autonomous robots are the answer to North America’s critical skills shortage.</li>
         <li class="p-list__item is-ticked">The results of its driverless snowplough deployment at Canada’s Winnipeg Richardson International Airport and what it means going forward.</li>

--- a/templates/engage/North-Americas-first-autonomous-runway-snowplough-case-study.html
+++ b/templates/engage/North-Americas-first-autonomous-runway-snowplough-case-study.html
@@ -1,5 +1,7 @@
 {% extends "engage/base_engage.html" %}
 
+{% block title %} North America&lsquo;s first autonomous runway snowplough{% endblock %}
+
 {% block meta_description %}Northstar Robotics, a Canadian tech start-up founded in 2016, wants to address these challenges by developing autonomous vehicles and wanted to find out if an entire network of vehicles can be powered by a single intelligent control system.{% endblock %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1uxXjTwzzhOQK7x9xpppWgRNVPLpnYA5BN1Mr1Zp2rHI/edit?ts=5ce644a0#heading=h.ud7r143one49{% endblock meta_copydoc %}
@@ -10,16 +12,16 @@
   <div class="row u-equal-height">
     <div class="col-7 u-vertically-center">
       <div>
-      <h1 class="u-no-margin--bottom u-sv3">
-        North America&lsquo;s first autonomous runway snowplough
-      </h1>
-      <p class="p-heading--four">The robots helping to address off-highway labour shortages</p>
-      <br class="u-hide--medium u-hide--large">
-      <p class="u-hide--medium u-hide--large">
-        <a href="#register-section" class="p-button--positive">
-          Download the case study
-        </a>
-      </p>
+        <h1 class="u-no-margin--bottom u-sv3">
+          North America&lsquo;s first autonomous runway snowplough
+        </h1>
+        <p class="p-heading--four">The robots helping to address off-highway labour shortages</p>
+        <br class="u-hide--medium u-hide--large">
+        <p class="u-hide--medium u-hide--large">
+          <a href="#the-form" class="p-button--positive">
+            Download the case study
+          </a>
+        </p>
       </div>
     </div>
     <div class="col-5 u-hide--small u-align--center u-vertically-center">
@@ -44,7 +46,7 @@
         <li class="p-list__item is-ticked">Why they chose support from Ubuntu above alternative distros.</li>
       </ul>
     </div>
-    <div class="col-5" id="register-section">
+    <div class="col-5" id="the-form">
       {% include "engage/shared/_en_engage_form.html" with id="3402" returnURL="https://pages.ubuntu.com/CStudy_Northstar-TY.html" cta="Download the case study" %}
     </div>
   </div>


### PR DESCRIPTION
## Done

Add Northstar landing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/engage/North-Americas-first-autonomous-runway-snowplough-case-study](http://0.0.0.0:8001/engage/North-Americas-first-autonomous-runway-snowplough-case-study)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure it complies with the [brief](https://docs.google.com/document/d/171v3o0-5sS_3Lii-KzwiYv83Uz2iRQATl6cknYF7qKE/edit?ts=5ced49ee#)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1164
