### PR TITLE
5204 persist query params on pagination links

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==2.2
 django-prometheus==1.0.15
-canonicalwebteam.blog==1.5.14
+canonicalwebteam.blog==1.5.15
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.django_views==1.3.4
 canonicalwebteam.get-feeds==0.2.4

--- a/templates/blog/pagination.html
+++ b/templates/blog/pagination.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-12">
       {% if current_page and total_pages and total_pages > 1 %}
-        {% with page_prefix=request.path|add:"?"|add:"&page="|replace:"?&,?" %}
+        {% with page_prefix=request|build_path_with_params|add:"&page="|replace:"?&,?" %}
         <ul class="p-inline-list--middot u-align--center" style="margin-bottom: 1rem;">
           {% if current_page > 1 %}
             <li class="p-inline-list__item"><a href="{{ page_prefix }}{{ current_page|add:"-1" }}">Previous</a></li>

--- a/webapp/templatetags/utils.py
+++ b/webapp/templatetags/utils.py
@@ -57,3 +57,17 @@ def months_list(year):
         if date < now.date():
             months.append({"name": date.strftime("%b"), "number": i})
     return months
+
+
+@register.filter
+def build_path_with_params(request):
+    query_params = request.GET.copy()
+    query_string = "?"
+
+    if "page" in query_params:
+        query_params.pop("page")
+
+    if len(query_params) > 0:
+        query_string += query_params.urlencode()
+
+    return request.path + query_string


### PR DESCRIPTION
## Done

Updated pagination template so non-pagination related query params are persisted when navigating via pagination links

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/blog/archives](http://0.0.0.0:8001/blog/archives)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click "2018" in the right-hand list of links, then click "2" in the list of pagination links
- See that the page contains a second set of posts from 2018, and the url ends with `?year=2018&page=2`

## Issue / Card

Fixes #5204 
