### PR TITLE
5123 improve blog card template

### DIFF
--- a/static/sass/_pattern_blog-card.scss
+++ b/static/sass/_pattern_blog-card.scss
@@ -84,6 +84,7 @@
 
   .blog-p-card__header {
     @extend %post-card-header;
+    border-top: 3px solid #666; //sass-lint:disable-line no-color-literals
 
     &--cloud-and-server {
       @extend %post-card-header;

--- a/static/sass/_pattern_blog-card.scss
+++ b/static/sass/_pattern_blog-card.scss
@@ -82,43 +82,40 @@
     }
   }
 
-  .blog-p-card__header {
+  // a fallback to catch any instances where a post.group exists,
+  // but we haven't yet defined a BEM variant to match
+  [class*="blog-p-card__header"] {
     @extend %post-card-header;
-    border-top: 3px solid #666; //sass-lint:disable-line no-color-literals
+    border-top: 3px solid $color-mid-dark;
+  }
+
+  .blog-p-card__header {
+    &--canonical-announcements {
+      border-color: #ff8936; //sass-lint:disable-line no-color-literals
+    }
 
     &--cloud-and-server {
-      @extend %post-card-header;
-      border-top: 3px solid #a87ca0; //sass-lint:disable-line no-color-literals
+      border-color: #a87ca0; //sass-lint:disable-line no-color-literals
     }
 
     &--desktop {
-      @extend %post-card-header;
-      border-top: 3px solid #faba54; //sass-lint:disable-line no-color-literals
+      border-color: #faba54; //sass-lint:disable-line no-color-literals
     }
 
     &--internet-of-things {
-      @extend %post-card-header;
-      border-top: 3px solid #8db255; //sass-lint:disable-line no-color-literals
-    }
-
-    &--canonical-announcements {
-      @extend %post-card-header;
-      border-top: 3px solid #ff8936; //sass-lint:disable-line no-color-literals
+      border-color: #8db255; //sass-lint:disable-line no-color-literals
     }
 
     &--phone-and-tablet {
-      @extend %post-card-header;
-      border-top: 3px solid $color-mid-light;
+      border-color: $color-mid-light;
     }
 
     &--webinar {
-      @extend %post-card-header;
-      border-top: 3px solid #48929b; //sass-lint:disable-line no-color-literals
+      border-color: #48929b; //sass-lint:disable-line no-color-literals
     }
 
     &--tutorials {
-      @extend %post-card-header;
-      border-top: 3px solid #47919e; //sass-lint:disable-line no-color-literals
+      border-color: #47919e; //sass-lint:disable-line no-color-literals
     }
   }
 

--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -31,9 +31,11 @@
       </a>
     </div>
     {% endif %}
+    
     <h3 class="p-heading--four">
       <a href="/blog/{{ article.slug }}">{{ article.title.rendered|safe }}</a>
     </h3>
+
     <p>
       <em
         >by
@@ -43,10 +45,12 @@
         on {{ article.date }}</em
       >
     </p>
-    {% if not article.image %}
-    <p class="u-no-padding--bottom">{{ article.excerpt.raw }}</p>
+
+    {% if summary_visible or not article.image %}
+    <p class="u-no-padding--bottom{% if summary_visible %} u-hide--small{% endif %}">{{ article.excerpt.raw|cut:"[…]"|truncatewords:36 }}</p>
     {% endif %}
   </div>
+
   <p class="blog-p-card__footer">
     {% include 'blog/singular-category.html' %}
   </p>

--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -1,17 +1,13 @@
 <div class="col-4 blog-p-card--post">
-  {% if article.group %}
-  <header class="blog-p-card__header blog-p-card__header--{{ article.group.slug }}">
+  <header class="blog-p-card__header{% if article.group %}--{{ article.group.slug }}{% endif %}">
     <h5 class="p-muted-heading u-no-margin--bottom">
-      {{ article.group.name }}
+      {% if article.group %}
+        {{ article.group.name }}
+      {% else %}
+        Ubuntu
+      {% endif %}
     </h5>
   </header>
-  {% else %}
-  <header class="blog-p-card__header">
-    <h5 class="p-muted-heading u-no-margin--bottom">
-      Ubuntu
-    </h5>
-  </header>
-  {% endif %}
   <div class="blog-p-card__content">
     {% if article.image and article.image.source_url %}
     <div class="u-crop--16-9">

--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -48,9 +48,7 @@
     {% endif %}
   </div>
   <p class="blog-p-card__footer">
-  {% if article.display_category %}
-     {{ article.display_category.name }}
-  {% endif %}
+    {% include 'blog/singular-category.html' %}
   </p>
 </div>
 

--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -8,6 +8,7 @@
   {% else %}
   <header class="blog-p-card__header">
     <h5 class="p-muted-heading u-no-margin--bottom">
+      Ubuntu
     </h5>
   </header>
   {% endif %}

--- a/templates/blog/featured-articles.html
+++ b/templates/blog/featured-articles.html
@@ -1,6 +1,5 @@
 {% block featured_articles %}
 
-
 <div class="p-strip--featured is-dark is-shallow u-no-margin--top" id="articles-list">
   <div class="row">
     <div class="col-12">
@@ -8,7 +7,7 @@
     </div>
     <div class="row u-equal-height u-clearfix">
       {% for article in featured_articles %}
-            {% include 'blog/blog-card.html' %}
+        {% include 'blog/blog-card.html' %}
       {% endfor %}
     </div>
   </div>

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -16,6 +16,8 @@
       {% endif %}
       {% if forloop.counter == 3 %}
         {% include 'blog/newsletter-form.html' %}
+      {% elif forloop.counter <= 2 %}
+        {% include 'blog/blog-card.html' with summary_visible=True %}
       {% else %}
         {% include 'blog/blog-card.html' %}
       {% endif %}

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -1,11 +1,13 @@
 <div class="col-4" style="position: sticky; top: 2rem;">
-  <div class="p-card">
-    <header class="p-card__header">
-      <h5 class="p-muted-heading">Newsletter signup</h5>
+  <div class="blog-p-card--muted">
+    <header class="blog-p-card__header">
+      <h5 class="p-muted-heading u-no-margin--bottom">Newsletter signup</h5>
     </header>
-    <h3 class="p-card--title">Select topics you&rsquo;re interested in</h3>
-    <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-      <div class="p-card--content">
+
+    <div class="blog-p-card__content">
+      <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
+        <h3 class="p-card--title p-heading--four">Select topics you&rsquo;re interested in</h3>
+        
         <ul class="p-list">
           <li class="p-list__item u-no-margin--top u-clearfix">
             <label>
@@ -13,18 +15,21 @@
               <label for="insightscloudserver">Cloud and Server</label>
             </label>
           </li>
+
           <li class="p-list__item u-no-margin--top u-clearfix">
             <label>
               <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop" />
               <label for="insightsdesktop">Desktop</label>
             </label>
           </li>
+
           <li class="p-list__item u-no-margin--top u-clearfix">
             <label>
               <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things" />
               <label for="insightsiot">Internet of Things</label>
             </label>
           </li>
+
           <li class="p-list__item u-no-margin--top u-clearfix">
             <label>
               <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
@@ -32,12 +37,14 @@
             </label>
           </li>
         </ul>
+
         <div class="mktFormReq mktField u-margin-medium--top">
           <label>
             <span class="u-no-margin--top">Work email: <span>*</span></span>
             <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
           </label>
         </div>
+
         <div class="mktField mktLblRight u-margin-medium--top">
           <span class="mktInput mktLblRight">
             <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="CanonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
@@ -47,19 +54,24 @@
             <span class="mktFormMsg"></span>
           </span>
         </div>
-        <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+
+        <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"></div>
+
         <p class="u-margin-medium--top">
           <small>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/newsletter">Canonical’s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</small>
         </p>
-
 
         <div class="u-margin-medium--top">
           <span class="mktoButtonWrap p-card--content">
             <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
           </span>
+
           <input type="hidden" name="Consent_to_Processing__c" value="yes" />
+          
           <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
+          
           <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
+          
           <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
           <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
           <input type="hidden" name="ret" value="{{request.build_absolute_uri}}?newsletter=true" />

--- a/templates/blog/singular-category.html
+++ b/templates/blog/singular-category.html
@@ -1,0 +1,15 @@
+{% if article.display_category.name == 'Articles' %}
+  Article
+{% elif article.display_category.name == 'Case studies' %}
+  Case study
+{% elif article.display_category.name == 'News' %}
+  News
+{% elif article.display_category.name == 'Webinars' %}
+  Webinar
+{% elif article.display_category.name == 'White papers' %}
+  White paper
+{% elif article.display_category.name %}
+  {{ article.display_category.name }}
+{% else %}
+  Article
+{% endif %}


### PR DESCRIPTION
## Done

- Ensured a group label is always present in a blog card header (defaults to "Ubuntu" if one isn't returned from the API)
- Added logic from blog.ubuntu.com to ensure a category label is always present in a blog card footer
- When a newsletter card is shown, ensured the blog cards on the same row display their post excerpts to reduce the amount of white space
- Updated newsletter card template to more closely match the one on blog.ubuntu.com

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/blog](http://0.0.0.0:8001/blog)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that blog cards on the same row as the newsletter display their summary
- Ensure blog cards listed throughout the blog each has:
  - a group label in its header
  - a category label in its footer

## Issue / Card

Fixes https://github.com/canonical-web-and-design/www.ubuntu.com/issues/5213

## Screenshots

![Screenshot 2019-05-29 at 14 20 30](https://user-images.githubusercontent.com/2376968/58560435-08835d00-821d-11e9-910d-7792864138ed.png)

![Screenshot 2019-05-29 at 14 20 53](https://user-images.githubusercontent.com/2376968/58560448-0caf7a80-821d-11e9-9af0-d54cdf8361ee.png)

