### PR TITLE
Add snappy topic page

### DIFF
--- a/static/sass/_pattern_blog-topic.scss
+++ b/static/sass/_pattern_blog-topic.scss
@@ -5,4 +5,9 @@
       height: 3.5rem;
     }
   }
+
+  .p-blog-topic__image {
+    position: absolute;
+    margin: 0;
+  }
 }

--- a/static/sass/_pattern_blog-topic.scss
+++ b/static/sass/_pattern_blog-topic.scss
@@ -5,9 +5,4 @@
       height: 3.5rem;
     }
   }
-
-  .p-blog-topic__image {
-    position: absolute;
-    margin: 0;
-  }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -53,6 +53,7 @@
 @include blog-p-list;
 @include blog-p-post;
 @include blog-p-strips-suru;
+@include blog-u-crop;
 @include blog-p-topic;
 @include ubuntu-p-buttons;
 @include ubuntu-p-card;

--- a/templates/blog/topics/snappy.html
+++ b/templates/blog/topics/snappy.html
@@ -6,12 +6,12 @@
 
 {% block content %} 
 
- <section class="p-strip--accent is-dark" style="background-color: #333;">
+ <section class="p-strip--accent p-blog-topic__strip is-dark">
     <div class="row header-strip u-equal-height">
       <div class="col-6">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header">
-            <img style="height: 3.5rem;" src="{{ASSET_SERVER_URL}}b46c8d7d-snapcraft-logo-hor-white.svg" alt=""/>
+            <img class="p-blog-topic__icon " src="{{ASSET_SERVER_URL}}b46c8d7d-snapcraft-logo-hor-white.svg" alt=""/>
           </div>
           <h2 class="p-heading--two">Package any app for any Linux and deliver updates directly</h2>
           <p class="p-heading--five">All the latest from the Snappy team &mdash; articles on application architecture, prototyping, packaging paradigms and more.</p>

--- a/templates/blog/topics/snappy.html
+++ b/templates/blog/topics/snappy.html
@@ -6,7 +6,7 @@
 
 {% block content %} 
 
-  <section class="p-strip--accent p-blog-topic__strip is-dark is-shallow u-image-position" style="overflow: hidden; background-color: #333">
+  <section class="p-strip--accent p-blog-topic__strip is-dark is-deep u-image-position" style="overflow: hidden; background-color: #333">
     <div class="row header-strip u-equal-height">
       <div class="col-6">
         <div class="p-heading-icon">

--- a/templates/blog/topics/snappy.html
+++ b/templates/blog/topics/snappy.html
@@ -11,7 +11,7 @@
       <div class="col-6">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header">
-            <img class="p-blog-topic__icon " src="{{ASSET_SERVER_URL}}b46c8d7d-snapcraft-logo-hor-white.svg" alt=""/>
+            <img class="p-blog-topic__icon" src="{{ASSET_SERVER_URL}}b46c8d7d-snapcraft-logo-hor-white.svg" alt=""/>
           </div>
           <h2 class="p-heading--two">Package any app for any Linux and deliver updates directly</h2>
           <p class="p-heading--five">All the latest from the Snappy team &mdash; articles on application architecture, prototyping, packaging paradigms and more.</p>
@@ -23,7 +23,8 @@
       <div class="col-5 prefix-1">
         <img
           src="{{ASSET_SERVER_URL}}a91f36a8-Snapcraft-Visual-Screen.png?w=576"
-          class="p-blog-topic__image u-hidden--small u-image-position--bottom"
+          class="u-hidden--small u-image-position--bottom"
+          style="position: absolute; margin: 0;"
           alt="" />
       </div>
     </div>

--- a/templates/blog/topics/snappy.html
+++ b/templates/blog/topics/snappy.html
@@ -6,7 +6,7 @@
 
 {% block content %} 
 
- <section class="p-strip--accent p-blog-topic__strip is-dark">
+ <section class="p-strip--accent p-blog-topic__strip is-dark is-shallow u-image-position" style="overflow: hidden; background-color: #333">
     <div class="row header-strip u-equal-height">
       <div class="col-6">
         <div class="p-heading-icon">
@@ -23,7 +23,7 @@
       <div class="col-5 prefix-1">
         <img
           src="{{ASSET_SERVER_URL}}a91f36a8-Snapcraft-Visual-Screen.png?w=576"
-          class="u-hidden--small u-image-position--bottom"
+          class="p-blog-topic__image u-hidden--small u-image-position--bottom"
           alt="" />
       </div>
     </div>

--- a/templates/blog/topics/snappy.html
+++ b/templates/blog/topics/snappy.html
@@ -1,0 +1,37 @@
+{% extends "templates/one-column.html" %} 
+
+{% block title %}Snapcraft and Snaps{% endblock %}
+
+{% block meta_description %}Package any app for any Linux and deliver updates directly. All the latest from the Snappy team &mdash; articles on application architecture, prototyping, packaging paradigms and more.{% endblock %}
+
+{% block content %} 
+
+ <section class="p-strip--accent is-dark" style="background-color: #333;">
+    <div class="row header-strip u-equal-height">
+      <div class="col-6">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            <img style="height: 3.5rem;" src="{{ASSET_SERVER_URL}}b46c8d7d-snapcraft-logo-hor-white.svg" alt=""/>
+          </div>
+          <h2 class="p-heading--two">Package any app for any Linux and deliver updates directly</h2>
+          <p class="p-heading--five">All the latest from the Snappy team &mdash; articles on application architecture, prototyping, packaging paradigms and more.</p>
+        </div>
+        <p>
+          <a class="p-link--external p-link--inverted" href="https://snapcraft.io">Learn more about Snapcraft</a>
+        </p>
+      </div>
+      <div class="col-5 prefix-1">
+        <img
+          src="{{ASSET_SERVER_URL}}a91f36a8-Snapcraft-Visual-Screen.png?w=576"
+          class="u-hidden--small u-image-position--bottom"
+          alt="" />
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip is-shallow" id="posts-list">
+    {% include 'blog/posts.html' %}
+  </section>
+
+  {% include 'blog/pagination.html' %}
+{% endblock %}

--- a/templates/blog/topics/snappy.html
+++ b/templates/blog/topics/snappy.html
@@ -6,15 +6,15 @@
 
 {% block content %} 
 
- <section class="p-strip--accent p-blog-topic__strip is-dark is-shallow u-image-position" style="overflow: hidden; background-color: #333">
+  <section class="p-strip--accent p-blog-topic__strip is-dark is-shallow u-image-position" style="overflow: hidden; background-color: #333">
     <div class="row header-strip u-equal-height">
       <div class="col-6">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header">
-            <img class="p-blog-topic__icon" src="{{ASSET_SERVER_URL}}b46c8d7d-snapcraft-logo-hor-white.svg" alt=""/>
+            <img class="p-blog-heading__icon" src="{{ASSET_SERVER_URL}}b46c8d7d-snapcraft-logo-hor-white.svg" alt=""/>
           </div>
-          <h2 class="p-heading--two">Package any app for any Linux and deliver updates directly</h2>
-          <p class="p-heading--five">All the latest from the Snappy team &mdash; articles on application architecture, prototyping, packaging paradigms and more.</p>
+          <p class="p-heading--three">Package any app for any Linux and deliver updates directly</p>
+          <p>All the latest from the Snappy team &mdash; articles on application architecture, prototyping, packaging paradigms and more.</p>
         </div>
         <p>
           <a class="p-link--external p-link--inverted" href="https://snapcraft.io">Learn more about Snapcraft</a>
@@ -24,7 +24,7 @@
         <img
           src="{{ASSET_SERVER_URL}}a91f36a8-Snapcraft-Visual-Screen.png?w=576"
           class="u-hidden--small u-image-position--bottom"
-          style="position: absolute; margin: 0;"
+          style="padding-top: 2.5rem; max-height: 100%;"
           alt="" />
       </div>
     </div>

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -59,6 +59,12 @@ urlpatterns += [
         {"slug": "design", "template_path": "blog/topics/design.html"},
         name="topic",
     ),
+    path(
+        r"blog/topics/snappy",
+        topic,
+        {"slug": "snappy", "template_path": "blog/topics/snappy.html"},
+        name="topic",
+    ),
     path(r"blog", include("canonicalwebteam.blog.django.urls")),
     url("", include("django_prometheus.urls")),
     url(


### PR DESCRIPTION
## Done

Add snappy topic page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/blog/topics/snappy](http://0.0.0.0:8001/blog/topics/snappy)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure it looks and behave similar to https://blog.ubuntu.com/topics/snappy


## Issue / Card

Fixes #5153 
