### PR TITLE
Add preconnect tag to gstatic.com

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -4,6 +4,7 @@
 <html class="no-js{% block extra_html_class %}{% endblock %}" lang="en" dir="ltr">
   <head>
     <link rel="preconnect" href="https://www.google-analytics.com">
+    <link rel="preconnect" href="https://www.gstatic.com">
     <link rel="preconnect" href="https://assets.ubuntu.com">
 
     <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2" crossorigin>


### PR DESCRIPTION
## Done

Add `preconnect` tag to gstatic.com

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Run a performance audit with Chrome DevTools and verify this is no longer a recommendation.

