### PR TITLE
Add font-display attribute to font loading

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -68,6 +68,12 @@
 @import "layout-whitepapers";
 @include layout-whitepapers;
 
+// Performant web font loading
+// https://developers.google.com/web/updates/2016/02/font-display
+body {
+  font-display: swap;
+}
+
 // Bug fixes
 // Each of the the rules below are bug fixes which need to be addressed further upstream
 // either at theme level or in Vanilla Framework directly.


### PR DESCRIPTION
## Done

Add `font-display: swap` attribute to font loading.

> The font swap period occurs immediately after the font block period. During this period, if the font face is not loaded, any element attempting to use it must instead render with a fallback font face. If the font face successfully loads during the swap period, the font face is then used normally.

Ref: https://developers.google.com/web/updates/2016/02/font-display

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Throttle the network on Chrome DevTools using a mobile emulator and observe fast font loading than in production.

Related: #4756 