### PR TITLE
Redirect /404 and /500 to homepage

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,4 +1,6 @@
 18.04: "/download"
+404/?: "/"
+500/?: "/"
 2009/.+/: "https://insights.ubuntu.com"
 2010/.+/: "https://insights.ubuntu.com"
 2011/.+/: "https://insights.ubuntu.com"


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/www.ubuntu.com/issues/1805#event-2358680518

QA
--

Check `/404` and `/500` go to homepage rather than displaying the 404 or 500 page.

Also check things like `/a-fake-page` still show 404 page.