### PR TITLE
Add Juju topic page

### DIFF
--- a/templates/blog/topics/juju.html
+++ b/templates/blog/topics/juju.html
@@ -6,7 +6,7 @@
 
 {% block content %} 
 
-  <section class="p-strip--accent p-blog-topic__strip is-dark is-shallow u-image-position" style="overflow: hidden; background-color: #333">
+  <section class="p-strip--accent p-blog-topic__strip is-dark is-deep u-image-position" style="overflow: hidden; background-color: #333">
     <div class="row header-strip u-equal-height">
       <div class="col-6">
         <div class="p-heading-icon">
@@ -24,13 +24,13 @@
         <img
           src="{{ASSET_SERVER_URL}}e8b86f15-Juju-Visual-Screen.png?w=576"
           class="u-hidden--small u-image-position--bottom"
-          style="padding-top: 1rem; max-height: 100%;"
+          style="padding-top: 2.5rem; max-height: 100%;"
           alt="" />
       </div>
     </div>
   </section>
 
-  <section class="p-strip is-shallow{% if current_page and current_page == 1 and upcoming_events %} is-bordered{% endif %}" id="posts-list">
+  <section class="p-strip is-shallow" id="posts-list">
     <div class="row u-equal-height u-clearfix">
     {% for article in articles %}
       {% if forloop.counter|add:"-1"|divisibleby:"3" and forloop.counter > 1 %}

--- a/templates/blog/topics/juju.html
+++ b/templates/blog/topics/juju.html
@@ -1,0 +1,46 @@
+{% extends "templates/one-column.html" %} 
+
+{% block title %}Juju and JAAS{% endblock %}
+
+{% block meta_description %}Operate big software at scale on any cloud. All the latest news on Juju – the open source application modelling tool for public and private clouds.{% endblock %}
+
+{% block content %} 
+
+  <section class="p-strip--accent p-blog-topic__strip is-dark is-shallow u-image-position" style="overflow: hidden; background-color: #333">
+    <div class="row header-strip u-equal-height">
+      <div class="col-6">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            <img class="p-blog-heading__icon" src="{{ASSET_SERVER_URL}}67057b2c-product-page-juju-logo.svg" alt=""/>
+          </div>
+          <p class="p-heading--three">Operate big software at scale on any cloud</p>
+          <p>All the latest news on Juju – the open source application modelling tool for public and private clouds.</p>
+        </div>
+        <p>
+          <a class="p-link--external p-link--inverted" href="https://jujucharms.com">Learn more about Juju</a>
+        </p>
+      </div>
+      <div class="col-5 prefix-1">
+        <img
+          src="{{ASSET_SERVER_URL}}e8b86f15-Juju-Visual-Screen.png?w=576"
+          class="u-hidden--small u-image-position--bottom"
+          style="padding-top: 1rem; max-height: 100%;"
+          alt="" />
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip is-shallow{% if current_page and current_page == 1 and upcoming_events %} is-bordered{% endif %}" id="posts-list">
+    <div class="row u-equal-height u-clearfix">
+    {% for article in articles %}
+      {% if forloop.counter|add:"-1"|divisibleby:"3" and forloop.counter > 1 %}
+        </div>
+        <div class="row u-equal-height u-clearfix">
+      {% endif %}
+      {% include 'blog/blog-card.html' %}
+    {% endfor %}
+    </div>
+  </section>
+
+  {% include 'blog/pagination.html' %}
+{% endblock %}

--- a/templates/blog/topics/juju.html
+++ b/templates/blog/topics/juju.html
@@ -30,16 +30,8 @@
     </div>
   </section>
 
-  <section class="p-strip is-shallow" id="posts-list">
-    <div class="row u-equal-height u-clearfix">
-    {% for article in articles %}
-      {% if forloop.counter|add:"-1"|divisibleby:"3" and forloop.counter > 1 %}
-        </div>
-        <div class="row u-equal-height u-clearfix">
-      {% endif %}
-      {% include 'blog/blog-card.html' %}
-    {% endfor %}
-    </div>
+  <section class="p-strip is-shallow">
+    {% include 'blog/posts.html' %}
   </section>
 
   {% include 'blog/pagination.html' %}

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -57,6 +57,13 @@ urlpatterns += [
         r"blog/topics/design",
         topic,
         {"slug": "design", "template_path": "blog/topics/design.html"},
+        r"blog/topics/juju",
+        name="topic",
+    ),
+    path(
+        r"blog/topics/juju",
+        topic,
+        {"slug": "juju", "template_path": "blog/topics/juju.html"},
         name="topic",
     ),
     path(r"blog", include("canonicalwebteam.blog.django.urls")),

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -57,7 +57,6 @@ urlpatterns += [
         r"blog/topics/design",
         topic,
         {"slug": "design", "template_path": "blog/topics/design.html"},
-        r"blog/topics/juju",
         name="topic",
     ),
     path(


### PR DESCRIPTION
## Done

Add Juju topic page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/blog/topics/juju](http://0.0.0.0:8001/blog/topics/juju)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure it looks and behaves similar to https://blog.ubuntu.com/topics/juju

## Issue / Card

Fixes #5155 
