### PR TITLE
1207 Update /openstack/training copy

### DIFF
--- a/templates/openstack/training.html
+++ b/templates/openstack/training.html
@@ -1,7 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
 {% block title %}Training | OpenStack{% endblock %}
-{% block meta_description %}Canonical run OpenStack and Ubuntu training programmes to suit all environments and all levels of experience.{% endblock meta_description %}
+{% block meta_description %}Canonical run OpenStack, Kubernetes and Ubuntu training programmes to suit all environments and all levels of experience.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit{% endblock meta_copydoc %}
 
 {% block outer_content %}
@@ -11,10 +11,10 @@
   <div class="row">
     <div class="col-6">
       <h1>Train with Ubuntu</h1>
-      <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of OpenStack. All classes and materials are provided in English.</p>
+      <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack or Charmed Kubernetes experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of your environment. All classes and materials are provided in English.</p>
     </div>
     <div class="col-6 u-hide--small" style="position: relative; margin-top: -6rem;">
-      <img class="u-image-position--top u-image-position--right u-hide--small u-no-margin--top" alt="" src="{{ ASSET_SERVER_URL }}c45cabb5-ubuntu-openstack-medals.svg" width="360" style="width: 360px;" />
+      <img class="u-image-position--top u-image-position--right u-hide--small u-no-margin--top" alt="" src="{{ ASSET_SERVER_URL }}652d2f5f-ubuntu-openstack-k8s-medals.svg" width="460" style="width: 460px;" />
     </div>
   </div>
 </section>
@@ -28,12 +28,12 @@
   <div class="row">
     <div class="col-12">
       <hr />
-      <h3 >On-site training</h3>
+      <h3>On-site Ubuntu Openstack cloud training</h3>
     </div>
   </div>
   <div class="row p-divider">
     <div class="col-7 p-divider__block">
-      <p>3-day hands-on course at your premises for up to 15 people that will give you the best introduction for setting up and running your own Ubuntu OpenStack cloud.</p>
+      <p>A three-day hands on course at your premises for up to 15 people that will give you the best introduction for setting up and running your own Ubuntu OpenStack cloud.</p>
       <p><a class="p-link--external" href="http://insights.ubuntu.com/wp-content/uploads/Ubuntu_OpenStack_Fundamentals_Training.pdf">Read the course outline (PDF)</a></p>
     </div>
     <div class="col-5 p-divider__block">
@@ -54,18 +54,17 @@
   <div class="row">
     <div class="col-12">
       <hr />
-      <h3 >High Availability Architecture add-on training</h3>
+      <h3>High Availability Architecture add-on training</h3>
     </div>
   </div>
   <div class="row p-divider">
     <div class="col-7 p-divider__block">
-      <p>This is a half day add-on course that is bundled with the OpenStack Fundamentals course, at your premises, for up to 15 students, that will provide fundamental instruction on High Availability for OpenStack.</p>
-      <p><a class="p-link--external" href="http://insights.ubuntu.com/wp-content/uploads/8032/ubuntu-openstack-high-availability-architecture.pdf">Read the course outline (PDF)</a></p>
+      <p>This half day add-on course is bundled with our OpenStack Fundamentals training. It provides key instruction on High Availability for OpenStack for up to 15 students at your premises.</p>
     </div>
     <div class="col-5 p-divider__block">
       <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
         <dt class="p-inline-definition-list__title">Duration</dt>
-        <dd class="p-inline-definition-list__item">4.5 hrs</dd>
+        <dd class="p-inline-definition-list__item">4.5 hrs (half day)</dd>
         <dt class="p-inline-definition-list__title">Cost</dt>
         <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="2000">2,000 </span> up to 15 attendees</dd>
         <dt class="p-inline-definition-list__title">Location</dt>
@@ -78,14 +77,46 @@
 
 <section class="p-strip is-bordered">
   <div class="row">
+    <div class="col-7">
+      <h2>OpenStack Operations</h2>
+    </div>
+  </div>
+  <div class="row">
     <div class="col-12">
-      <h2>Ubuntu Server Administration</h2>
-      <h3 >Basic on-site training</h3>
+      <hr />
+      <h3>On-site training: how to operate Ubuntu OpenStack</h3>
     </div>
   </div>
   <div class="row p-divider">
     <div class="col-7 p-divider__block">
-      <p>3-day hands-on course at your premises for up to 15 students, that will provide fundamental instruction on how to install and administer Ubuntu Server.</p>
+      <p>A five-day hands on course at your premises for up to 15 people that guides you through all aspects of performing effective operations on your Ubuntu OpenStack cloud. A follow-up course to OpenStack Fundamentals, it guides you through operational tasks such as monitoring, troubleshooting, patching, scaling, and upgrading, while keeping your cloud available and performing.</p>
+    </div>
+    <div class="col-5 p-divider__block">
+      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
+        <dt class="p-inline-definition-list__title">Duration</dt>
+        <dd class="p-inline-definition-list__item">5 days</dd>
+        <dt class="p-inline-definition-list__title">Cost</dt>
+        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="29500">29,500</span> up to 15 attendees</dd>
+        <dt class="p-inline-definition-list__title">Location</dt>
+        <dd class="p-inline-definition-list__item">Your premises</dd>
+        <dt class="p-inline-definition-list__title">Availability</dt>
+        <dd class="p-inline-definition-list__item">Private groups only</dd>
+      </dl>
+      <p><a href="/openstack/contact-us?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Ubuntu Server Administration</h2>
+      <h3>Basic on-site Ubuntu Server training</h3>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="col-7 p-divider__block">
+      <p>A three-day hands on course at your premises for up to 15 students, that teaches you how to install and administer Ubuntu Server.</p>
       <p><a class="p-link--external" href="http://insights.ubuntu.com/wp-content/uploads/1ee7/Training_basic-Ubuntu-server-administration.pdf">Read the course outline (PDF)</a></p>
     </div>
     <div class="col-5 p-divider__block">
@@ -96,6 +127,8 @@
         <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
         <dt class="p-inline-definition-list__title">Location</dt>
         <dd class="p-inline-definition-list__item">Your premises</dd>
+        <dt class="p-inline-definition-list__title">Availability</dt>
+        <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
       <p><a href="/openstack/contact-us?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
@@ -103,12 +136,12 @@
   <div class="row">
     <div class="col-12">
       <hr />
-      <h3 >Advanced on-site training</h3>
+      <h3>Advanced on-site Ubuntu Server training</h3>
     </div>
   </div>
   <div class="row p-divider">
     <div class="col-7 p-divider__block">
-      <p>You&rsquo;ve been using Ubuntu Server for a while and want to advance your skills. The Ubuntu Advanced Server course is an intensive 3-day hands-on course in which you will learn and use advanced techniques.</p>
+      <p>You&rsquo;ve been using Ubuntu Server for a while and want to advance your skills. The Ubuntu Advanced Server course is an intensive three-day hands on course in which you will learn and use advanced techniques.</p>
       <p><a class="p-link--external" href="https://insights.ubuntu.com/wp-content/uploads/138d/Training_Advanced-server-administration_02.17.pdf">Read the course outline (PDF)</a></p>
     </div>
     <div class="col-5 p-divider__block">
@@ -119,13 +152,74 @@
         <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
         <dt class="p-inline-definition-list__title">Location</dt>
         <dd class="p-inline-definition-list__item">Your premises</dd>
+        <dt class="p-inline-definition-list__title">Availability</dt>
+        <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
       <p><a href="/openstack/contact-us?product=openstack-training-server-admin" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <h2>Kubernetes Explorer</h2>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <hr />
+      <h3>On-site Charmed Kubernetes training</h3>
+    </div>
+  </div>
+
+  <div class="row p-divider">
+    <div class="col-7 p-divider__block">
+      <p>A three-day hands on course at your premises for up to 15 people that guides you through Charmed Kubernetes. You will learn about Kubernetes, how to deploy and configure it, as well as how to perform operational actions such as live upgrades.</p>
+      <p><a class="p-link--external" href="https://assets.ubuntu.com/v1/bdff2205-Kubernetes+Training+Curriculum.pdf">Read the course outline (PDF)</a></p>
+    </div>
+    <div class="col-5 p-divider__block">
+      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
+        <dt class="p-inline-definition-list__title">Duration</dt>
+        <dd class="p-inline-definition-list__item">3 days</dd>
+        <dt class="p-inline-definition-list__title">Cost</dt>
+        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">19,500</span> up to 15 attendees</dd>
+        <dt class="p-inline-definition-list__title">Location</dt>
+        <dd class="p-inline-definition-list__item">Your premises</dd>
+        <dt class="p-inline-definition-list__title">Availability</dt>
+        <dd class="p-inline-definition-list__item">Private groups only</dd>
+      </dl>
+      <p><a href="/openstack/contact-us?product=kubernetes-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <hr />
+      <h3>Bare Metal add-on training</h3>
+    </div>
+  </div>
+
+  <div class="row p-divider">
+    <div class="col-7 p-divider__block">
+      <p>This is a half day add-on course that is offered as an extension to the Kubernetes Explorer. It focuses on managing your bare metal in an automated way with MAAS so that you can deploy Kubernetes easily and effortlessly. It takes place at your premises for up to 15 students. </p>
+    </div>
+    <div class="col-5 p-divider__block">
+      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
+        <dt class="p-inline-definition-list__title">Duration</dt>
+        <dd class="p-inline-definition-list__item">1 day</dd>
+        <dt class="p-inline-definition-list__title">Cost</dt>
+        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="6500">6,500</span> up to 15 attendees</dd>
+        <dt class="p-inline-definition-list__title">Location</dt>
+        <dd class="p-inline-definition-list__item">Your premises</dd>
+      </dl>
+      <p><a href="/openstack/contact-us?product=/openstack/contact-us?product=kubernetes-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
   <div class="row">
     <div class="col-7">
       <h2>Questions about training?</h2>

--- a/templates/openstack/training.html
+++ b/templates/openstack/training.html
@@ -203,7 +203,7 @@
 
   <div class="row p-divider">
     <div class="col-7 p-divider__block">
-      <p>This is a half day add-on course that is offered as an extension to the Kubernetes Explorer. It focuses on managing your bare metal in an automated way with MAAS so that you can deploy Kubernetes easily and effortlessly. It takes place at your premises for up to 15 students. </p>
+      <p>This is an add-on course that is offered as an extension to the Kubernetes Explorer. It focuses on managing your bare metal in an automated way with MAAS so that you can deploy Kubernetes easily and effortlessly. It takes place at your premises for up to 15 students.</p>
     </div>
     <div class="col-5 p-divider__block">
       <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">


### PR DESCRIPTION
## Done

- updated copy on /openstack/training per the [copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit)
- added new image in header

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/openstack/training](http://0.0.0.0:8001/openstack/training)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page matches the [copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1207

## Notes / Questions

There's also been [a request](https://docs.google.com/a/canonical.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit?disco=AAAACwiU_N0) to update the path this training doc lives at from `/openstack/training` to `/training`, and have it linked to from within both Openstack and Kubernetes sections. Should "Training" also exist as a link at a higher level? Or just within those sections?
