### PR TITLE
5157: Implement robotics topic page

### DIFF
--- a/templates/blog/topics/robotics.html
+++ b/templates/blog/topics/robotics.html
@@ -1,0 +1,37 @@
+{% extends "templates/one-column.html" %} 
+
+{% block title %}Robotics{% endblock %}
+
+{% block meta_description %}All the latest news on robotics from Canonical.{% endblock %}
+
+{% block content %}
+
+  <section class="p-strip is-deep is-bordered u-image-position">
+    <div class="row u-equal-height">
+      <div class="col-6">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            <img class="p-heading-icon__img" src="{{ASSET_SERVER_URL}}c5cb0f8e-picto-ubuntu.svg" alt="" style="align-self: center;"/>
+            
+            <h1 class="p-heading--one u-no-margin--top u-no-margin--bottom">Robotics</h1>
+          </div>
+          <p>Whether you’re starting in the lab or already in production, Canonical can help manage the complexity of the open-source software underpinning your robot’s brains and personality.</p>
+        </div>
+
+        <p>
+          <a class="p-link--external" href="/internet-of-things/robotics">Learn more about robotics from Canonical</a>
+        </p>
+      </div>
+
+      <div class="col-5 prefix-1 u-align--center u-vertically-center">
+        <img src="{{ASSET_SERVER_URL}}5b16cbb9-robot_2px.svg" class="u-hidden--small" alt="" />
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip is-shallow">
+    {% include 'blog/posts.html' %}
+  </section>
+
+  {% include 'blog/pagination.html' %}
+{% endblock %}

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -15,7 +15,7 @@ urlpatterns = create_redirect_views()
 urlpatterns += create_deleted_views()
 urlpatterns += [
     path(
-        r"blog/cloud-and-server",
+        "blog/cloud-and-server",
         group,
         {
             "slug": "cloud-and-server",
@@ -24,13 +24,13 @@ urlpatterns += [
         name="group",
     ),
     path(
-        r"blog/desktop",
+        "blog/desktop",
         group,
         {"slug": "desktop", "template_path": "blog/desktop.html"},
         name="group",
     ),
     path(
-        r"blog/press-centre",
+        "blog/press-centre",
         group,
         {
             "slug": "canonical-announcements",
@@ -39,7 +39,7 @@ urlpatterns += [
         name="group",
     ),
     path(
-        r"blog/internet-of-things",
+        "blog/internet-of-things",
         group,
         {
             "slug": "internet-of-things",
@@ -48,24 +48,30 @@ urlpatterns += [
         name="group",
     ),
     path(
-        r"blog/topics/maas",
+        "blog/topics/maas",
         topic,
         {"slug": "maas", "template_path": "blog/topics/maas.html"},
         name="topic",
     ),
     path(
-        r"blog/topics/design",
+        "blog/topics/design",
         topic,
         {"slug": "design", "template_path": "blog/topics/design.html"},
         name="topic",
     ),
     path(
-        r"blog/topics/juju",
+        "blog/topics/juju",
         topic,
         {"slug": "juju", "template_path": "blog/topics/juju.html"},
         name="topic",
     ),
-    path(r"blog", include("canonicalwebteam.blog.django.urls")),
+    path(
+        "blog/topics/robotics",
+        topic,
+        {"slug": "robotics", "template_path": "blog/topics/robotics.html"},
+        name="topic",
+    ),
+    path("blog", include("canonicalwebteam.blog.django.urls")),
     url("", include("django_prometheus.urls")),
     url(
         r"^(?P<template>download/(desktop|server|cloud)/thank-you)$",


### PR DESCRIPTION
## Done

- Added /blog/topics/robotics template

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/blog/topics/robotics](http://0.0.0.0:8001/blog/topics/robotics)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the page looks and behaves similarly to https://blog.ubuntu.com/topics/robotics


## Issue / Card

Fixes #5157 
