### PR TITLE
5210 add topics dropdown to blog navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -236,8 +236,10 @@ blog:
       path: /blog/desktop          
     - title: Cloud and Server
       path: /blog/cloud-and-server         
+    - title: Topics
+      path: /blog/topics
     - title: Press centre
-      path: /blog/press-centre  
+      path: /blog/press-centre
     - title: Archives
       path: /blog/archives
     - title: Upcoming

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -238,6 +238,19 @@ blog:
       path: /blog/cloud-and-server         
     - title: Topics
       path: /blog/topics
+
+      children:
+        - title: Design
+          path: /blog/topics/design
+        - title: Juju
+          path: /blog/topics/juju
+        - title: MAAS
+          path: /blog/topics/maas
+        - title: Robotics
+          path: /blog/topics/robotics
+        - title: Snapcraft
+          path: /blog/topics/snappy
+
     - title: Press centre
       path: /blog/press-centre
     - title: Archives

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -68,7 +68,21 @@
     {% if breadcrumbs.children %}
     <ul class="breadcrumbs--secondary col-12">
       {% for child in breadcrumbs.children %}
-        {% if child.path != '/blog/archives' and child.path != '/blog/upcoming'%}
+        {% if child.path == '/blog/topics' %}
+        <li class="breadcrumbs__item p-contextual-menu">
+          <a aria-controls="#topics" class="breadcrumbs__link p-link--soft p-contextual-menu__toggle" href="#">{{ child.title }}</a>
+
+          <span class="p-contextual-menu__dropdown" id="topics" aria-hidden="true" aria-label="submenu" style="left: 1rem; font-size: 14px;">
+            <span class="p-contextual-menu__group">
+              <a href="/blog/topics/design" class="p-contextual-menu__link">Design</a>
+              <a href="/blog/topics/juju" class="p-contextual-menu__link">Juju</a>
+              <a href="/blog/topics/maas" class="p-contextual-menu__link">MAAS</a>
+              <a href="/blog/topics/robotics" class="p-contextual-menu__link">Robotics</a>
+              <a href="/blog/topics/snappy" class="p-contextual-menu__link">Snapcraft</a>
+            </span>
+          </span>
+        </li>
+        {% elif child.path != '/blog/archives' and child.path != '/blog/upcoming' %}
         <li class="breadcrumbs__item">
           <a class="breadcrumbs__link {% if child.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ child.path }}">{{ child.title }}</a>
         </li>
@@ -116,4 +130,58 @@
       console.log('Request failed', error)
     })
   }
+</script>
+
+<script>
+  function toggleMenu(toggle, dropdown, show) {
+    toggle.setAttribute('aria-expanded', show);
+    dropdown.setAttribute('aria-hidden', !show);
+  }
+
+  function setupContextualMenuListeners(contextualMenuSelector) {
+    var menus = document.querySelectorAll(contextualMenuSelector);
+    
+    for (var i = 0; i < menus.length; i++) {
+      var toggle = menus[i].querySelector('.p-contextual-menu__toggle'),
+          dropdown = menus[i].querySelector('.p-contextual-menu__dropdown'),
+          timer = null;
+
+      toggle.addEventListener('click', function(e) {
+        e.preventDefault();
+      });
+
+      toggle.addEventListener('mouseover', function() {
+        clearTimeout(timer);
+        toggleMenu(toggle, dropdown, true);
+      });
+
+      toggle.addEventListener('mouseleave', function() {
+        toggleMenu(toggle, dropdown, true);
+
+        timer = setTimeout(function() {
+          toggleMenu(toggle, dropdown, false);
+        }, 50);
+      });
+
+      dropdown.addEventListener('mouseover', function() {
+        clearTimeout(timer);
+      });
+
+      dropdown.addEventListener('mouseleave', function() {
+        timer = setTimeout(function() {
+          toggleMenu(toggle, dropdown, false);
+        }, 50);
+      });
+
+      document.onkeydown = function(e) {
+        e = e || window.event;
+
+        if (e.keyCode === 27) {
+          toggleMenu(toggle, dropdown, false);
+        }
+      };
+    };
+  }
+
+  setupContextualMenuListeners('.p-contextual-menu');
 </script>

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -102,7 +102,7 @@
         {% if child.path == "/blog/topics" %}
           {% for item in child.children %}
           <li class="breadcrumbs__item u-hide--medium u-hide--large">
-            <a class="breadcrumbs__link p-link--soft" href="{{ item.path }}">{{ item.title }}</a>
+            <a class="breadcrumbs__link {% if request.path == item.path %}p-link--active{% else %}p-link--soft {% endif %}" href="{{ item.path }}">{{ item.title }}</a>
           </li>
           {% endfor %}
         {% endif %}

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -72,13 +72,13 @@
         <li class="breadcrumbs__item p-contextual-menu">
           <a aria-controls="#topics" class="breadcrumbs__link p-link--soft p-contextual-menu__toggle" href="#">{{ child.title }}</a>
 
-          <span class="p-contextual-menu__dropdown" id="topics" aria-hidden="true" aria-label="submenu" style="left: 1rem; font-size: 14px;">
+          <span class="p-contextual-menu__dropdown" id="topics" aria-hidden="true" aria-label="submenu" style="left: 1rem; font-size: .875rem;">
             <span class="p-contextual-menu__group">
-              <a href="/blog/topics/design" class="p-contextual-menu__link">Design</a>
-              <a href="/blog/topics/juju" class="p-contextual-menu__link">Juju</a>
-              <a href="/blog/topics/maas" class="p-contextual-menu__link">MAAS</a>
-              <a href="/blog/topics/robotics" class="p-contextual-menu__link">Robotics</a>
-              <a href="/blog/topics/snappy" class="p-contextual-menu__link">Snapcraft</a>
+              <a href="/blog/topics/design" class="p-contextual-menu__link breadcrumbs p-link--soft">Design</a>
+              <a href="/blog/topics/juju" class="p-contextual-menu__link breadcrumbs p-link--soft">Juju</a>
+              <a href="/blog/topics/maas" class="p-contextual-menu__link breadcrumbs p-link--soft">MAAS</a>
+              <a href="/blog/topics/robotics" class="p-contextual-menu__link breadcrumbs p-link--soft">Robotics</a>
+              <a href="/blog/topics/snappy" class="p-contextual-menu__link breadcrumbs p-link--soft">Snapcraft</a>
             </span>
           </span>
         </li>

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -69,16 +69,14 @@
     <ul class="breadcrumbs--secondary col-12">
       {% for child in breadcrumbs.children %}
         {% if child.path == '/blog/topics' %}
-        <li class="breadcrumbs__item p-contextual-menu">
-          <a aria-controls="#topics" class="breadcrumbs__link p-link--soft p-contextual-menu__toggle" href="#">{{ child.title }}</a>
+        <li class="breadcrumbs__item p-contextual-menu u-hide--small">
+          <a aria-controls="#topics" class="breadcrumbs__link {% if child.active %}p-link--active{% else %}p-link--soft{% endif %} p-contextual-menu__toggle" href="#">{{ child.title }}</a>
 
           <span class="p-contextual-menu__dropdown" id="topics" aria-hidden="true" aria-label="submenu" style="left: 1rem; font-size: .875rem;">
             <span class="p-contextual-menu__group">
-              <a href="/blog/topics/design" class="p-contextual-menu__link breadcrumbs p-link--soft">Design</a>
-              <a href="/blog/topics/juju" class="p-contextual-menu__link breadcrumbs p-link--soft">Juju</a>
-              <a href="/blog/topics/maas" class="p-contextual-menu__link breadcrumbs p-link--soft">MAAS</a>
-              <a href="/blog/topics/robotics" class="p-contextual-menu__link breadcrumbs p-link--soft">Robotics</a>
-              <a href="/blog/topics/snappy" class="p-contextual-menu__link breadcrumbs p-link--soft">Snapcraft</a>
+              {% for item in child.children %}
+              <a href="{{ item.path }}" class="p-contextual-menu__link breadcrumbs p-link--soft">{{ item.title }}</a>
+              {% endfor %}
             </span>
           </span>
         </li>
@@ -87,16 +85,27 @@
           <a class="breadcrumbs__link {% if child.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ child.path }}">{{ child.title }}</a>
         </li>
         {% endif %}
-      {% if breadcrumbs.grandchildren %}
-      <li class="breadcrumbs__item"><span class="breadcrumbs__chevron u-hide--small">&rsaquo;</span><span class="u-show--small">&nbsp;</span></li>
-      {% for grandchild in breadcrumbs.grandchildren %}
-      <li class="breadcrumbs__item">
-        <a class="breadcrumbs__link {% if grandchild.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ grandchild.path }}">
-          {{ grandchild.title }}
-        </a>
-      </li>
+
+        {% if breadcrumbs.grandchildren %}
+        <li class="breadcrumbs__item"><span class="breadcrumbs__chevron u-hide--small">&rsaquo;</span><span class="u-show--small">&nbsp;</span></li>
+          {% for grandchild in breadcrumbs.grandchildren %}
+          <li class="breadcrumbs__item">
+            <a class="breadcrumbs__link {% if grandchild.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ grandchild.path }}">
+              {{ grandchild.title }}
+            </a>
+          </li>
+          {% endfor %}
+        {% endif %}
       {% endfor %}
-      {% endif %}
+      
+      {% for child in breadcrumbs.children %}
+        {% if child.path == "/blog/topics" %}
+          {% for item in child.children %}
+          <li class="breadcrumbs__item u-hide--medium u-hide--large">
+            <a class="breadcrumbs__link p-link--soft" href="{{ item.path }}">{{ item.title }}</a>
+          </li>
+          {% endfor %}
+        {% endif %}
       {% endfor %}
     </ul>
     {% endif %}

--- a/webapp/context_processors.py
+++ b/webapp/context_processors.py
@@ -21,10 +21,16 @@ def navigation(request):
     path = request.path
     breadcrumbs = {}
     nav_sections = deepcopy(settings.NAV_SECTIONS)
+    is_topic_page = path.startswith("/blog/topics")
 
     for nav_section_name, nav_section in nav_sections.items():
         for child in nav_section["children"]:
-            if child["path"] == path:
+            if is_topic_page and child["path"] == ("/blog/topics"):
+                child["active"] = True
+                breadcrumbs["section"] = nav_section
+                breadcrumbs["children"] = nav_section.get("children", [])
+                break
+            elif child["path"] == path:
                 child["active"] = True
                 nav_section["active"] = True
                 breadcrumbs["section"] = nav_section


### PR DESCRIPTION
## Done

- added Vanilla's contextual menu pattern to blog navigation for topics

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/blog](http://0.0.0.0:8001/blog)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click "Topics" in the navigation, ensure that you can see the dropdown list of topics, and that each of the links works


## Issue / Card

Fixes #5210 
