### PR TITLE
WIP: Add schema, open graph and twitter meta-data to pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,236 @@
+{% extends "templates/one-column.html" %}
+
+{% block title %}Ubuntu solutions for telecommunications{% endblock %}
+{% block meta_description %}Companies around the world rely on Ubuntu for secure open source solutions. We work with our customers to meet the highest security standards.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/15FY_IaT39V81FQcoSoEJpmRRjBX80PJ7uxjgzHnDDws/edit{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip--image is-dark is-deep" style="background-image: url('{{ ASSET_SERVER_URL }}ebdfffbf-Aubergine_suru_background.png'); background-position: 77% 0%;">
+  <div class="row">
+    <div class="col-8">
+      <h1>Ubuntu for telcos</h1>
+      <p>As an established leader in cloud computing, Canonical lets you apply the webscale savings and best practice  that are necessary to succeed in the telco world. By using established open source software to automate the deployment and operation of NFVI and IoT solutions, we can help you become even more agile while reducing your costs and time to market.</p>
+      <ul class="p-inline-list">
+        <li class="p-inline-list__item">
+          <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/290067" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch Cloud to Edge webinar', 'eventLabel' : 'Watch Cloud to Edge webinar', 'eventValue' : undefined });" ><span class="p-link--external">Watch the 'Cloud to Edge' webinar</span></a>
+        </li>
+        <li class="p-inline-list__item">
+          <a href="/cloud/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Telcos - Top CTA' });" class="p-button--neutral js-invoke-modal">Contact us</a>
+        </li>
+      </ul>
+    </p>
+  </div>
+  <div class="col-4">
+    <img src="{{ ASSET_SERVER_URL }}49b9302b-network-equipment-white.svg?w=200" width="200" alt="">
+  </div>
+</div>
+</section>
+
+<section class="p-strip is-deep is-bordered">
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block">
+      <h2 class="p-heading--three">Cost-saving automation</h2>
+      <p>Cut operating costs with automated scaling. You can deploy thousands of identical sites, creating an infrastructure that's built from the ground up for operations at the lowest possible cost. Canonical&rsquo;s open source tooling and focus on automation makes it easy to deploy cloud environments, again and again. </p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h2 class="p-heading--three">Carrier-grade uptime</h2>
+      <p>Deploy a carrier grade product suite in line with ETSI frameworks, while remaining aligned with upstream projects to ensure easy upgrades. Unrivalled security and resilience are intrinsic to our Communication Service Provider (CSP) solutions &mdash; which means guaranteed uptime for you.</p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h2 class="p-heading--three">Expert knowledge and experience</h2>
+      <p>Our team of specialists operates production CSP environments around the globe, covering the entire environment life-cycle, from deployment to upgrades and onboarding virtual network functions &mdash; enabling you to realise the true potential of your cloud.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <h2>Why choose Canonical?</h2>
+    <ul class="p-list is-split">
+      <li class="p-list__item is-ticked">Keep <abbr title="Capital expenditure">CAPEX</abbr> and <abbr title="Operating expenses">OPEX</abbr> costs down with virtualisation and automation</li>
+      <li class="p-list__item is-ticked">Peace of mind with a pre-tested solution</li>
+      <li class="p-list__item is-ticked">Get started quicker with our speedy onboarding process</li>
+      <li class="p-list__item is-ticked">High-availability <abbr title="Service-level agreement">SLA</abbr>s aligned with accepted industry practices</li>
+      <li class="p-list__item is-ticked">Stay ahead with easy upgrades between OpenStack versions and fast access to the latest OpenStack features with 100% upstream integration</li>
+    </ul>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-6 p-card--highlighted">
+      <h2 class="p-card__title">The complete cloud automation toolset</h2>
+      <p class="p-card__content">Operational discipline &mdash; built on automation and repeatability &mdash; has long been crucial to the profitability of CSPs. Canonical applies the same principles to the way clouds are built and run.  From design to deployment and operations, every aspect is managed with Canonical&rsquo;s proven automation toolset, the: provisioning tool MAAS, management tool Landscape, and application modeling tool Juju.</p>
+      <ul class="p-card__content p-list">
+        <li><a class="p-link--external" href="https://jujucharms.com/">Find out more about Juju</a></li>
+        <li><a class="p-link--external" href="https://maas.io/">Find out more about MAAS</a></li>
+      </ul>
+    </div>
+    <div class="col-6 p-card--highlighted">
+      <h2 class="p-card__title">NFVI cloud build</h2>
+      <div class="p-card__content">
+        <p>Canonical&rsquo;s Private Cloud Build for telcos is a pre-tested, pre-integrated OpenStack cloud built using a proven reference architecture and tailored to the needs of CSPs.</p>
+        <p>Think of it as a fixed price, NFV-ready cloud, deployed by Canonical on your premises in just a few weeks.</p>
+        <p><a href="/openstack/consulting">Find out more<span class="u-off-screen"> about NFVI cloud build</span>&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card--highlighted">
+      <h2 class="p-card__title">A telco-grade managed cloud</h2>
+      <div class="p-card__content">
+        <p>A number of telcos rely on Canonical&rsquo;s fully managed cloud service. Get Telco Grade SLAs and predictable operational costs for your OpenStack cloud, on your servers at your locations. We build, operate, scale and upgrade your cloud, while you concentrate on building your applications in flexible and agile environments.</p>
+        <p><a href="/openstack/consulting">Find out more<span class="u-off-screen"> about Canonical&rsquo;s managed cloud</span>&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+    <div class="col-6 p-card--highlighted">
+      <h2 class="p-card__title">Smart edge: Internet of Things, switches and <abbr title="Customer-Premises Equipment">CPE</abbr>s</h2>
+      <div class="p-card__content">
+        <p>Ubuntu is the Operating System of choice for the smart edge. From software-defined top of the rack switch to enterprise CPE, from home IoT gateways to digital signage, Canonical offers secure OS and app store solutions to maximise post sales revenue from all your smart devices.</p>
+        <p><a href="/internet-of-things">Find out more<span class="u-off-screen"> about smart edge</span>&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="p-strip--accent is-deep">
+  <div class="row">
+    <div class="col-12">
+      <blockquote class="p-pull-quote">
+        <p>We&rsquo;re reinventing how we scale by becoming simpler and modular, similar to how applications have evolved in cloud data centers. Open source and OpenStack innovations represent a unique opportunity to meet these requirements and Canonical&rsquo;s cloud and open source expertise make them a good choice for AT&amp;T.</p>
+        <cite class="p-pull-quote__citation">Toby Ford, Assistant Vice President of Cloud Technology, Strategy and Planning at AT&amp;T</cite>
+      </blockquote>
+    </div>
+  </div>
+</div>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-muted-heading u-align--center">A selection of our telecommunications clients</h2>
+      <ul class="p-inline-images">
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}25de1877-Tele2.svg" width="90" alt="Tele2" style="max-width:90px;" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}03a06060-logo-deutschetelekom.svg" width="242" alt="Deutshe Telekom" style="max-width:130px;" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}b6e008be-Colt-Logo.svg" width="100" alt="Colt" style="max-width:100px;" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}481063cd-pccw.svg" width="144" alt="PCCW" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}d8f890fb-logo-at%26t.svg" width="145" alt="AT&T" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}9ca791fd-Sky_Logo_seit_Dezember_2015.png?w=90" width="90" alt="Sky" style="max-width:90px;" />
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-muted-heading u-align--center">A selection of the telco programs we are part of</h2>
+      <ul class="p-inline-images">
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}d10b4578-etsi.svg" width="88" alt="ETSI" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}4a8b06e9-onap_logo.png?w=144" width="144" alt="ONAP" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}f15a069c-opnfv_logo_wp.png?w=144" width="144" alt="OPNFV" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}88982890-OSM-logo.png?w=144" width="144" alt="Open Source MANO" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}5ac9bab5-logo_cord-1.png?w=144" width="144" alt="CORD" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}9e564bf9-open-baton.png?w=120" width="120" alt="Open Baton" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}9635c8f7-opencompute-logo-green.png?w=144" width="144" alt="Open Compute" />
+        </li>
+        <li class="p-inline-images__item">
+          <img style="width: 300px;" class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}eeae998a-telecominfraproject-logo.svg" width="144" alt="Telecom Infra Project" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}061ffe4a-onf-logo.jpg?w=144" width="144" alt="ONF" />
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2 class="p-heading--three">Learn about Ubuntu in the telecommunications sector</h2>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block" id="ubuntu-com_telco_left">
+      <!-- rtp section start -->
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' width="32" alt='' />
+          <h4 class='p-heading-icon__title'>Whitepaper</h4>
+        </div>
+      </div>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://insights.ubuntu.com/2016/06/15/special-report-low-latency-and-real-time-kernels-for-telco-and-nfv/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Telco - left', 'eventLabel' : 'Whitepaper - Read our report on low latency and real-time kernels for telco and NFV', 'eventValue' : '1' });'>Read our report on low latency and real-time kernels for telco and NFV</a></h3>
+      <!-- rtp section end -->
+    </div>
+    <div class="col-4 p-divider__block" id="ubuntu-com_telco_center">
+      <!-- rtp section start -->
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg' width="32" alt='' />
+          <h4 class='p-heading-icon__title'>Webinar</h4>
+        </div>
+      </div>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://insights.ubuntu.com/2017/03/16/webinar-learn-the-secrets-to-innovative-and-scalable-vnf-deployment/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Telco - center', 'eventLabel' : 'Webinar - Learn the secrets to innovative and scalable VNF deployment', 'eventValue' : '1' });'>Learn the secrets to innovative and scalable VNF deployment</a></h3>
+      <!-- rtp section end -->
+    </div>
+    <div class="col-4 p-divider__block" id="ubuntu-com_telco_right">
+      <!-- rtp section start -->
+      <div class='p-heading-icon--muted'>
+        <div class='p-heading-icon__header'>
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg' width="32" alt='' />
+          <h4 class='p-heading-icon__title'>Ebook</h4>
+        </div>
+      </div>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://insights.ubuntu.com/2016/05/16/ebook-ctos-guide-to-sdn-nfv-vnf/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'Telco - right', 'eventLabel' : 'Ebook - CTO’s guide to SDN, NFV and VNF', 'eventValue' : '1' });'><span hidden>Read the ebook </span>CTO’s guide to SDN, NFV and VNF</a></h3>
+      <!-- rtp section end -->
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--accent">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h4>Find out how Canonical helps you to apply the webscale savings and best practice for success in the telco world.</h4>
+      <ul class="p-inline-list">
+        <li class="p-inline-list__item">
+          <a href="https://www.brighttalk.com/webcast/6793/290067" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Footer CTA', 'eventLabel' : 'Watch Cloud to Edge webinar' });"><span class="p-link--external">Watch the 'Cloud to Edge' webinar</span></a>
+        </li>
+        <li class="p-inline-list__item">
+          <a href="/cloud/contact-us" class="p-button--neutral js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Footer CTA', 'eventLabel' : 'Contact us' });">Contact us</a>
+        </li>
+      </ul>
+    </div>
+    <div class="col-4 prefix-1 suffix-1 u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="144" class="u-hide--small" alt="">
+    </div>
+  </div>
+</section>
+
+{% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_newsletter" third_item="_telco_further_reading" %}
+{% endblock content %}

--- a/templates/engage/starting-with-ai.html
+++ b/templates/engage/starting-with-ai.html
@@ -1,13 +1,19 @@
 {% extends "engage/base_engage.html" %}
 
-{% block title %}Getting Started with AI{% endblock %}
+{% setvar "Getting Started with AI" as meta_title %}
 
-{% block meta_description %}From the smallest startups to the largest enterprises alike, organizations are using Artificial Intelligence and Machine Learning to make the best, fastest, most informed decisions to overcome their biggest business challenges.{% endblock %}
+{% setvar "From the smallest startups to the largest enterprises alike, organizations are using Artificial Intelligence and Machine Learning to make the best, fastest, most informed decisions to overcome their biggest business challenges." as description %}
+
+{% setvar "166a4103-ai-get-started.svg" as image %}
+
+{% block title %}{{ meta_title }}{% endblock %}
+
+{% block meta_description %}{{ description }}{% endblock %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1oC74jvhUvWudAG4dQ7TluAQlY6DiM_b28_tDvL_ue-Q{% endblock meta_copydoc %}
 
-{% block content %}
 
+{% block content %}
 <section class="p-strip p-strip--dark p-takeover--ai">
   <div class="row u-equal-height">
     <div class="col-7  u-vertically-center">
@@ -32,6 +38,9 @@
 <section class="p-strip is-shallow is-bordered">
   <div class="row">
     <div class="col-7">
+      {% setvar "Getting Started with AI" as meta_title %}
+
+      <h1>{{ meta_title }}</h1>
       <p>
         From the smallest startups to the largest enterprises alike, organizations are using Artificial Intelligence and Machine Learning to make the best, fastest, most informed decisions to overcome their biggest business challenges.
       </p>

--- a/templates/shared/meta_data/open-graph.html
+++ b/templates/shared/meta_data/open-graph.html
@@ -1,7 +1,7 @@
 <meta content="ubuntu.com" property="og:site_name">
     <meta content="en_GB" property="og:locale" />
-    <meta content="{% block title %}Ubuntu{% endblock %}" property="og:title">
+    <meta content="{{ title }}" property="og:title">
     <meta content="{% if "/engage" in request.path %}article{% else %}website{% endif %}" property="og:type">
-    <meta content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}" property="og:description">
-    <meta content="{{ request.path }}" property="og:url">
-    <meta content="{% if meta_image %}{{ ASSET_SERVER_URL }}{{ meta_image }}{% else %}{{ ASSET_SERVER_URL }}3361409d-apple-touch-icon-144x144-precomposed.png{% endif %}" property="og:image">
+    <meta content="{{ description }}" property="og:description">
+    <meta content="https://www.ubuntu.com{{ request.path }}" property="og:url">
+    <meta content="{% if image %}{{ ASSET_SERVER_URL }}{{ image }}{% else %}{{ ASSET_SERVER_URL }}3361409d-apple-touch-icon-144x144-precomposed.png{% endif %}" property="og:image">

--- a/templates/shared/meta_data/open-graph.html
+++ b/templates/shared/meta_data/open-graph.html
@@ -1,0 +1,7 @@
+<meta content="ubuntu.com" property="og:site_name">
+    <meta content="en_GB" property="og:locale" />
+    <meta content="{% block title %}Ubuntu{% endblock %}" property="og:title">
+    <meta content="{% if "/engage" in request.path %}article{% else %}website{% endif %}" property="og:type">
+    <meta content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}" property="og:description">
+    <meta content="{{ request.path }}" property="og:url">
+    <meta content="{% if meta_image %}{{ ASSET_SERVER_URL }}{{ meta_image }}{% else %}{{ ASSET_SERVER_URL }}3361409d-apple-touch-icon-144x144-precomposed.png{% endif %}" property="og:image">

--- a/templates/shared/meta_data/schema-org-article.html
+++ b/templates/shared/meta_data/schema-org-article.html
@@ -1,0 +1,21 @@
+<script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@type": "NewsArticle",
+        "mainEntityOfPage": {
+          "@type": "WebPage",
+          "@id": "https://google.com/article"
+        },
+        "headline": "{% block title %}Ubuntu{% endblock %}",
+        "image": "{% if meta_image %}{{ ASSET_SERVER_URL }}{{ meta_image }}{% else %}{{ ASSET_SERVER_URL }}3361409d-apple-touch-icon-144x144-precomposed.png{% endif %}",
+        "publisher": {
+          "@type": "Organization",
+          "name": "Canonical",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "{{ ASSET_SERVER_URL }}3361409d-apple-touch-icon-144x144-precomposed.png"
+          }
+        },
+        "description": "{{ meta_description }}"
+      }
+    </script>

--- a/templates/shared/meta_data/schema-org-article.html
+++ b/templates/shared/meta_data/schema-org-article.html
@@ -6,8 +6,8 @@
           "@type": "WebPage",
           "@id": "https://google.com/article"
         },
-        "headline": "{% block title %}Ubuntu{% endblock %}",
-        "image": "{% if meta_image %}{{ ASSET_SERVER_URL }}{{ meta_image }}{% else %}{{ ASSET_SERVER_URL }}3361409d-apple-touch-icon-144x144-precomposed.png{% endif %}",
+        "headline": "{{ title }}",
+        "image": "{% if image %}{{ ASSET_SERVER_URL }}{{ image }}{% else %}{{ ASSET_SERVER_URL }}3361409d-apple-touch-icon-144x144-precomposed.png{% endif %}",
         "publisher": {
           "@type": "Organization",
           "name": "Canonical",
@@ -16,6 +16,6 @@
             "url": "{{ ASSET_SERVER_URL }}3361409d-apple-touch-icon-144x144-precomposed.png"
           }
         },
-        "description": "{{ meta_description }}"
+        "description": "{{ description }}"
       }
     </script>

--- a/templates/shared/meta_data/twitter.html
+++ b/templates/shared/meta_data/twitter.html
@@ -1,0 +1,7 @@
+<meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@ubuntu">
+    <meta name="twitter:title" content="{% block title %}Ubuntu{% endblock %}">
+    <meta name="twitter:description" content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}">
+    <meta name="twitter:creator" content="@ubuntu">
+    <meta name="twitter:image" content="{% if meta_image %}{{ ASSET_SERVER_URL }}{{ meta_image }}{% else %}{{ ASSET_SERVER_URL }}3361409d-apple-touch-icon-144x144-precomposed.png{% endif %}">
+    <meta name="twitter:domain" content="www.ubuntu.com">

--- a/templates/shared/meta_data/twitter.html
+++ b/templates/shared/meta_data/twitter.html
@@ -1,7 +1,7 @@
 <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@ubuntu">
-    <meta name="twitter:title" content="{% block title %}Ubuntu{% endblock %}">
-    <meta name="twitter:description" content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}">
+    <meta name="twitter:title" content="{{ title }}">
+    <meta name="twitter:description" content="{{  description  }}">
     <meta name="twitter:creator" content="@ubuntu">
-    <meta name="twitter:image" content="{% if meta_image %}{{ ASSET_SERVER_URL }}{{ meta_image }}{% else %}{{ ASSET_SERVER_URL }}3361409d-apple-touch-icon-144x144-precomposed.png{% endif %}">
+    <meta name="twitter:image" content="{% if image %}{{ ASSET_SERVER_URL }}{{ image }}{% else %}{{ ASSET_SERVER_URL }}3361409d-apple-touch-icon-144x144-precomposed.png{% endif %}">
     <meta name="twitter:domain" content="www.ubuntu.com">

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -18,6 +18,8 @@
 
     <meta charset="UTF-8" />
     <meta name="description" content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}" />
+    <meta name="description" content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}" />
+
 
     <meta name="author" content="Canonical" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -58,6 +60,10 @@
     </script>
 
     {% block head_extra %}{% endblock %}
+
+    {% include "shared/meta_data/schema-org-article.html" with meta_description=meta_description %}
+    {% include "shared/meta_data/open-graph.html" %}
+    {% include "shared/meta_data/twitter.html" %}
 
     {% block crazy_egg %}{% endblock crazy_egg %}
     <!-- google webmaster tools verification -->

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -18,8 +18,6 @@
 
     <meta charset="UTF-8" />
     <meta name="description" content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}" />
-    <meta name="description" content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}" />
-
 
     <meta name="author" content="Canonical" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -61,7 +59,7 @@
 
     {% block head_extra %}{% endblock %}
 
-    {% include "shared/meta_data/schema-org-article.html" with meta_description=meta_description %}
+    {% include "shared/meta_data/schema-org-article.html" %}
     {% include "shared/meta_data/open-graph.html" %}
     {% include "shared/meta_data/twitter.html" %}
 

--- a/webapp/templatetags/utils.py
+++ b/webapp/templatetags/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from django import template
 import dateutil.parser
+import re
 
 register = template.Library()
 
@@ -39,3 +40,39 @@ def keyvalue(dictionary, key_name):
     """
 
     return dictionary.get(key_name)
+
+
+# Variables
+class SetVarNode(template.Node):
+    def __init__(self, new_val, var_name):
+        self.new_val = new_val
+        self.var_name = var_name
+
+    def render(self, context):
+        context[self.var_name] = self.new_val
+        return ""
+
+
+@register.tag
+def setvar(parser, token):
+    # This version uses a regular expression to parse tag contents.
+
+    try:
+        # Splitting by None == splitting by spaces.
+        tag_name, arg = token.contents.split(None, 1)
+    except ValueError:
+        raise template.TemplateSyntaxError(
+            "%r tag requires arguments" % token.contents.split()[0]
+        )
+    m = re.search(r"(.*?) as (\w+)", arg)
+    if not m:
+        raise template.TemplateSyntaxError(
+            "%r tag had invalid arguments" % tag_name
+        )
+    new_val, var_name = m.groups()
+    if not (new_val[0] == new_val[-1] and new_val[0] in ('"', "'")):
+        raise template.TemplateSyntaxError(
+            "%r tag's argument should be in quotes" % tag_name
+        )
+
+    return SetVarNode(new_val[1:-1], var_name)


### PR DESCRIPTION
## Done

- Use title and description and an optional image to add schema.org, open graph and twitter meta data to pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
