### PR TITLE
[RFC] Extra metadata handling for engage pages

### DIFF
--- a/templates/engage/starting-with-ai.html
+++ b/templates/engage/starting-with-ai.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Getting Started with AI{% endblock %}
-
-{% block meta_description %}From the smallest startups to the largest enterprises alike, organizations are using Artificial Intelligence and Machine Learning to make the best, fastest, most informed decisions to overcome their biggest business challenges.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Getting started with AI" meta_image="https://assets.ubuntu.com/v1/83facbfb-getting-started-with-ai.png" meta_description="From the smallest startups to the largest enterprises alike, organizations are using Artificial Intelligence and Machine Learning to make the best, fastest, most informed decisions to overcome their biggest business challenges." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1oC74jvhUvWudAG4dQ7TluAQlY6DiM_b28_tDvL_ue-Q{% endblock meta_copydoc %}
 

--- a/templates/templates/_extra_metadata.html
+++ b/templates/templates/_extra_metadata.html
@@ -1,0 +1,22 @@
+    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}" />
+    <meta name="theme-color" content="#E95420" />
+    <meta name="twitter:account_id" content="4503599627481511" />
+    <meta name="twitter:site" content="@ubuntu">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://www.ubuntu.com{{ request.get_full_path }}" />
+    <meta property="og:site_name" content="Ubuntu" />
+
+    {% if title %}
+        <meta name="twitter:title" content="{{ title }} | Ubuntu">
+        <meta property="og:title" content="{{ title }} | Ubuntu" />
+    {% endif %}
+    {% if meta_description %}
+        <meta name="twitter:description" content="{{ meta_description }}">
+        <meta property="og:description" content="{{ meta_description }}" />
+    {% endif %}
+    {% if meta_image %}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:image" content="{{ meta_image }}">
+        <meta property="og:image" content="{{ meta_image }}" />
+    {% endif %}
+    

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -17,17 +17,13 @@
     {% include "templates/_tag_manager.html" %}
 
     <meta charset="UTF-8" />
-    <meta name="description" content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}" />
-
+    <meta name="description" content="{% block meta_description %}{{ meta_description | default:"Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things."}}{% endblock %}" />
     <meta name="author" content="Canonical" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta property="twitter:account_id" content="4503599627481511" />
-    <meta name="google-site-verification" content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M" />
-    <meta name="theme-color" content="#E95420" />
 
-    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}" />
+    {% include "templates/_extra_metadata.html" %}
 
-    <title>{% block title %}{% endblock %} | Ubuntu</title>
+    <title>{% block title %}{{ title }}{% endblock %} | Ubuntu</title>
 
     <link rel="preconnect" href="https://www.google-analytics.com">
     <link rel="preconnect" href="https://assets.ubuntu.com">

--- a/webapp/templatetags/utils.py
+++ b/webapp/templatetags/utils.py
@@ -68,7 +68,8 @@ def do_extends_with_args(parser, token):
     kwargs = {}
     if "with" in bits:
         pos = bits.index("with")
-        argslist = bits[pos + 1:]
+        argspos = pos + 1
+        argslist = bits[argspos:]
         bits = bits[:pos]
         for i in argslist:
             a, b = i.split("=", 1)


### PR DESCRIPTION
This pull request is a proposal for a new way to handle metadata for pages such as engage pages, where having an extra layer of metadata for social sharing is critical.

Currently we surface things such as page description through template blocks, but when the content needs to duplicated across tags, this doesn't scale, especially since Django doesn't allow duplicating blocks in the extended template.

This proposal introduces:
*  an "extends_with_args" template tag, that wraps around "extends" and allows setting context variables from extension pages.
* an `_extra_metadata.html` which makes use of these args to build social sharing metadata for Twitter, FB, etc.
* an example (`/engage/starting-with-ai`)

The benefits of this approach is that it doesn't conflict with our existing template layers and metadata surfacing, it's simply a new method that cloud be the preferred one for engage pages.

## QA

- Using the demo, test the following pages on https://socialdebug.com/:
  * `/engage/19-04-webinar`
  * `/engage/starting-with-ai`
  * `/desktop/developers`
- For each page, ensure the "overall score" for the demo is not regressing compared to prod
- Test the same pages on https://cards-dev.twitter.com/validator
- ~and on https://developers.facebook.com/tools/debug/sharing~ / it's using the canonical URL, hence failing on the demo.

