### PR TITLE
Update Active Directory takeover and engage page headlines

### DIFF
--- a/templates/engage/microsoft-active-directory.html
+++ b/templates/engage/microsoft-active-directory.html
@@ -12,7 +12,7 @@
   <div class="row u-equal-height">
     <div class="col-8 u-vertically-center">
       <h1 class="u-no-margin--bottom">
-        How to integrate Ubuntu Desktop with Active Directory
+        How to integrate Ubuntu with Active&nbsp;Directory
       </h1>
       <br class="u-hide--medium u-hide--large">
       <p class="u-hide--medium u-hide--large">
@@ -39,13 +39,13 @@
         Ubiquitous use of Microsoft tools coupled with increasing popularity of open source Linux software for enterprise presents new challenges for non-Microsoft operating systems that require seamless integration with Active Directory for authentication and identity management. This is because Active Directory was never designed as a cross-platform directory service.
       </p>
       <p>
-        Integrating <a href="/download/desktop">Ubuntu Desktop</a> 18.04 LTS into an existing Active Directory architecture can be an automated and effortless process when using the Powerbroker Identity Service Open tool (PBIS Open), a derivative of <a href="https://www.beyondtrust.com/tools/ad-bridging" class="p-link--external">BeyondTrust&rsquo;s</a> Open-Source Active Directory Bridging. 
+        Integrating <a href="/download/desktop">Ubuntu Desktop</a> 18.04 LTS into an existing Active Directory architecture can be an automated and effortless process when using the Powerbroker Identity Service Open tool (PBIS Open), a derivative of <a href="https://www.beyondtrust.com/tools/ad-bridging" class="p-link--external">BeyondTrust&rsquo;s</a> Open-Source Active Directory Bridging.
       </p>
       <blockquote class="p-pull-quote">
         <p>Integrating Ubuntu Desktop into an existing Active Directory architecture can be an automated and effortless process</p>
       </blockquote>
       <p>
-        This whitepaper provides detailed insights and step-by-step instructions for using PBIS Open to integrate Ubuntu Desktop into Active Directory and suggests alternative solutions in cases where it is not a suitable option.  
+        This whitepaper provides detailed insights and step-by-step instructions for using PBIS Open to integrate Ubuntu Desktop into Active Directory and suggests alternative solutions in cases where it is not a suitable option.
       </p>
       <h4>
         What can I learn from this whitepaper?
@@ -55,7 +55,7 @@
           Overview, benefits and drawbacks of using PBIS Open to integrate third party operating systems into an existing Microsoft Active Directory architecture.
         </li>
         <li class="p-list__item is-ticked">
-          Detailed steps for PBIS Open set up and integrating Ubuntu into Active Directory. 
+          Detailed steps for PBIS Open set up and integrating Ubuntu into Active Directory.
         </li>
         <li class="p-list__item is-ticked">
           Alternative tools to integrate Ubuntu into Active Directory.

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
-  {% include "takeovers/_active-directory_takeover.html" %}
+  {# include "takeovers/_active-directory_takeover.html" #}
   {% include "takeovers/_starting-with-ai-takeover.html" %}
   {% include "takeovers/_451-automotive_takeover.html" %}
   {% include "takeovers/_1904-webinar_takeover.html" %}

--- a/templates/takeovers/_active-directory_takeover.html
+++ b/templates/takeovers/_active-directory_takeover.html
@@ -2,7 +2,7 @@
   <div class="row u-clearfix u-vertically-center">
     <div class="col-7 ">
       <h1>
-        Integrating Ubuntu Desktop with Active Directory
+        How to integrate Ubuntu with Active&nbsp;Directory
       </h1>
       <h4 class="p-heading--four">
         A step by step guide to joining your desktops to Active Directory

--- a/templates/takeovers/_active-directory_takeover.html
+++ b/templates/takeovers/_active-directory_takeover.html
@@ -5,8 +5,7 @@
         How to integrate Ubuntu with Active&nbsp;Directory
       </h1>
       <h4 class="p-heading--four">
-        A step by step guide to joining your desktops to Active Directory
-        domains.
+        A step by step guide to joining your desktops to Active&nbsp;Directory domains.
       </h4>
       <a href="/engage/microsoft-active-directory?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Desktop_Whitepaper_ActiveDirectory" class="p-button--positive u-hide--small">
         <span>Download the whitepaper</span>


### PR DESCRIPTION
## Done

- Changed the headline to work better 'How to integrate Ubuntu with Active Directory'
- Hid the takeover as it has been delayed to the 13 June 2019

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the h1 has change and that there is a nbsp on the work 'Active Directory'

