### PR TITLE
Add https links for ask ubuntu and ubuntuforums

### DIFF
--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -105,8 +105,8 @@
         <h3 class="p-card__title">Need help with Ubuntu?</h3>
         <p>If you are just looking for some free support for yourself, you can try:</p>
         <ul class="p-list--divided">
-          <li class="p-list__item"><a class="p-link--external" href="http://askubuntu.com/">Ask Ubuntu</a></li>
-          <li class="p-list__item"><a class="p-link--external" href="http://ubuntuforums.org/">The Ubuntu forum</a></li>
+          <li class="p-list__item"><a class="p-link--external" href="https://askubuntu.com/">Ask Ubuntu</a></li>
+          <li class="p-list__item"><a class="p-link--external" href="https://ubuntuforums.org/">The Ubuntu forum</a></li>
           <li class="p-list__item"><a class="p-link--external" href="https://help.ubuntu.com/">Help docs</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Done

Add https links for ask ubuntu and ubuntuforums

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/ai/contact-us](http://0.0.0.0:8001/ai/contact-us)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that https is used for ask ubuntu and ubuntuforums

## Issue / Card

Fixes #5273
