### PR TITLE
Update links on /community

### DIFF
--- a/templates/community/index.html
+++ b/templates/community/index.html
@@ -53,7 +53,7 @@
           <p>Discover community generated how-to’s, tips, tricks and hacks on the <a href="https://help.ubuntu.com/community/CommunityHelpWiki" class="p-link--external">community help wiki</a>.</p>
         </li>
         <li>
-          <p>Get the latest Ubuntu news and resources on our <a href="http://insights.ubuntu.com/" class="p-link--external">insights blog</a>.</p>
+          <p>Get the latest Ubuntu news and resources on our <a href="https://blog.ubuntu.com/" class="p-link--external">insights blog</a>.</p>
         </li>
       </ul>
       <h3>Connect</h3>
@@ -61,11 +61,11 @@
       <ul>
         <li>
           <p>Navigate the Ubuntu world by joining an Internet Relay Chat such as #ubuntu<br>
-          <a href="https://community.ubuntu.com/t/internet-relay-chat/24/1" class="p-link--external">Learn more about Internet Relay Chat (IRC)</a></p>
+          <a href="https://discourse.ubuntu.com/t/internet-relay-chat/24/1" class="p-link--external">Learn more about Internet Relay Chat (IRC)</a></p>
         </li>
         <li>
           <p>Are you stuck and need help? Find support from a variety of sources.<br>
-          <a href="https://community.ubuntu.com/t/community-support/709" class="p-link--external">More information about community support</a></p>
+          <a href="https://discourse.ubuntu.com/t/community-support/709" class="p-link--external">More information about community support</a></p>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Done

Update links on /community

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/community](http://0.0.0.0:8001/community)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- see that the link to the insights.u.c now goes to blog.u.c and that the links to community.u.c now use discourse.u.c

## Issue / Card

Fixes #5270