### PR TITLE
fixed hero (added image back)

### DIFF
--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-<section class="p-strip is-deep">
+<section class="p-strip is-deep" style="background-image: url('https://assets.ubuntu.com/v1/214648ba-_M8A2368-final.jpg?w=1280'); background-repeat: no-repeat; background-size: cover; background-position: bottom center;">
   <div class="row">
     <div class="col-12 suffix-7">
       <div class="p-card--overlay">


### PR DESCRIPTION
## Done

The hero image was removed by mistake. I added it back.

## QA

- Check out this feature branch
- Check if the image is there
- Run the site using the command `./run serve`
- View the site locally in your web browser at: /desktop/organisations
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


