### PR TITLE
3077: update maas provisioning screenshots

### DIFF
--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -96,7 +96,7 @@
               <li>Ubuntu images</li>
               <li><abbr title="Secure shell">SSH</abbr> keys (for currently logged in user)</li>
             </ul>
-            <p><a href="{{ ASSET_SERVER_URL }}267759eb-complete-the-first-user-configuration-journey.png" class="venobox venobox--expand" data-gall="installGallery" title="Initial screen of the first use journey"><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}267759eb-complete-the-first-user-configuration-journey.png?w=552" width="552" alt="First user journey screenshot"></a></p>
+            <p><a href="{{ ASSET_SERVER_URL }}e0915052-initial_setup.png" class="venobox venobox--expand" data-gall="installGallery" title="Initial screen of the first use journey"><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}e0915052-initial_setup.png?w=552" width="552" alt="First user journey screenshot"></a></p>
           </div>
         </li>
         <li class="p-list-step__item">
@@ -111,8 +111,8 @@
               <li>Select the subnet where to create the DHCP Dynamic range on.</li>
               <li>Fill in the details for the dynamic range.</li>
             </ol>
-            <p><a href="{{ ASSET_SERVER_URL }}c3010cc2-turn-on-DHCP.png" class="venobox venobox--expand" data-gall="installGallery" title="VLAN details page in an active MAAS">
-              <img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}c3010cc2-turn-on-DHCP.png?w=552" width="552" class="image--shadow" alt="VLAN details">
+            <p><a href="{{ ASSET_SERVER_URL }}65c03778-provide_DHCP.png" class="venobox venobox--expand" data-gall="installGallery" title="VLAN details page in an active MAAS">
+              <img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}65c03778-provide_DHCP.png?w=552" width="552" class="image--shadow" alt="VLAN details">
             </a></p>
           </div>
         </li>
@@ -130,8 +130,8 @@
               <li>Select all the machines and &ldquo;Commission&rdquo; them using the &ldquo;Take action&rdquo; button</li>
               <li>When machines have a &ldquo;Ready&rdquo; status you can start deploying</li>
             </ol>
-            <p><a href="{{ ASSET_SERVER_URL }}66a25be9-enlist-and-commission-servers.png" class="venobox venobox--expand" data-gall="installGallery" title="The node listing page in MAAS">
-              <img src="{{ ASSET_SERVER_URL }}66a25be9-enlist-and-commission-servers.png?w=552" width="552" class="p-image--bordered" alt="MAAS node listing">
+            <p><a href="{{ ASSET_SERVER_URL }}94f90490-machine_listing.png" class="venobox venobox--expand" data-gall="installGallery" title="The node listing page in MAAS">
+              <img src="{{ ASSET_SERVER_URL }}94f90490-machine_listing.png?w=552" width="552" class="p-image--bordered" alt="MAAS node listing">
             </a></p>
             <p><a class="p-link--external" href="https://docs.ubuntu.com/maas/2.3/en/">Refer to the user manual to get a more detailed guide in how to get up and running with MAAS</a></p>
           </div>

--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -96,7 +96,7 @@
               <li>Ubuntu images</li>
               <li><abbr title="Secure shell">SSH</abbr> keys (for currently logged in user)</li>
             </ul>
-            <p><a href="{{ ASSET_SERVER_URL }}e0915052-initial_setup.png" class="venobox venobox--expand" data-gall="installGallery" title="Initial screen of the first use journey"><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}e0915052-initial_setup.png?w=552" width="552" alt="First user journey screenshot"></a></p>
+            <p><a href="{{ ASSET_SERVER_URL }}e0915052-initial_setup.png" title="Initial screen of the first use journey"><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}e0915052-initial_setup.png?w=552" width="552" alt="First user journey screenshot"></a></p>
           </div>
         </li>
         <li class="p-list-step__item">
@@ -111,7 +111,7 @@
               <li>Select the subnet where to create the DHCP Dynamic range on.</li>
               <li>Fill in the details for the dynamic range.</li>
             </ol>
-            <p><a href="{{ ASSET_SERVER_URL }}65c03778-provide_DHCP.png" class="venobox venobox--expand" data-gall="installGallery" title="VLAN details page in an active MAAS">
+            <p><a href="{{ ASSET_SERVER_URL }}65c03778-provide_DHCP.png" title="VLAN details page in an active MAAS">
               <img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}65c03778-provide_DHCP.png?w=552" width="552" class="image--shadow" alt="VLAN details">
             </a></p>
           </div>
@@ -130,7 +130,7 @@
               <li>Select all the machines and &ldquo;Commission&rdquo; them using the &ldquo;Take action&rdquo; button</li>
               <li>When machines have a &ldquo;Ready&rdquo; status you can start deploying</li>
             </ol>
-            <p><a href="{{ ASSET_SERVER_URL }}94f90490-machine_listing.png" class="venobox venobox--expand" data-gall="installGallery" title="The node listing page in MAAS">
+            <p><a href="{{ ASSET_SERVER_URL }}94f90490-machine_listing.png" title="The node listing page in MAAS">
               <img src="{{ ASSET_SERVER_URL }}94f90490-machine_listing.png?w=552" width="552" class="p-image--bordered" alt="MAAS node listing">
             </a></p>
             <p><a class="p-link--external" href="https://docs.ubuntu.com/maas/2.3/en/">Refer to the user manual to get a more detailed guide in how to get up and running with MAAS</a></p>


### PR DESCRIPTION
## Done

Updated MAAS provisioning screenshots

## QA

- Check out this feature branch
- Run the site using the command `./run`
- View the site locally in your web browser at: [/download/server/provisioning](http://0.0.0.0:8001/download/server/provisioning)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the screenshots have been updated from the (out of date) screenshots currently on the [live site](https://www.ubuntu.com/download/server/provisioning)


## Issue / Card

Fixes #3077 
